### PR TITLE
Fixed JSON preety printer for x64 build

### DIFF
--- a/src/inc/json.h
+++ b/src/inc/json.h
@@ -85,7 +85,9 @@ public:
     json & operator << (string) throw();
     json & operator << (number) throw();
     json & operator << (integer) throw();
-    json & operator << (long unsigned int d) throw();
+    json & operator << (unsigned long int d) throw();
+    json & operator << (unsigned long long int d) throw();
+    json & operator << (long long int d) throw();
     json & operator << (boolean) throw();
     json & operator << (_null_t) throw();
     json & operator << (_context_t) throw();

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -131,10 +131,12 @@ json & json::operator << (json::number f) throw()
         fprintf(_stream, "%g", f); 
     return *this; 
 }
-json & json::operator << (json::integer d) throw()  { context(seq); fprintf(_stream, "%ld", d); return *this; }
-json & json::operator << (long unsigned d) throw()  { context(seq); fprintf(_stream, "%ld", d); return *this; }
-json & json::operator << (json::boolean b) throw()  { context(seq); fputs(b ? "true" : "false", _stream); return *this; }
-json & json::operator << (json::_null_t) throw()    { context(seq); fputs("null",_stream); return *this; }
+json & json::operator << (json::integer d) throw()          { context(seq); fprintf(_stream, "%ld", d); return *this; }
+json & json::operator << (unsigned long int d) throw()      { context(seq); fprintf(_stream, "%lu", d); return *this; }
+json & json::operator << (unsigned long long int d) throw() { context(seq); fprintf(_stream, "%llu", d); return *this; }
+json & json::operator << (long long int d) throw()          { context(seq); fprintf(_stream, "%lld", d); return *this; }
+json & json::operator << (json::boolean b) throw()          { context(seq); fputs(b ? "true" : "false", _stream); return *this; }
+json & json::operator << (json::_null_t) throw()            { context(seq); fputs("null",_stream); return *this; }
 
 #endif
 


### PR DESCRIPTION
I had problems while building library using Mingw-w64, so I wrote a small patch.
Fixed errors:
1. ./src/gr_logging.cpp:170:37: error: ambiguous overload for 'operator<<' (operand types are 'graphite2::json' and 'size_t {aka long long unsigned int}')
2. unsigned long int was treated as signed long int at ./src/json.cpp:135:95
3. ./src/Intervals.cpp:280:17: error: ambiguous overload for 'operator<<' (operand types are 'graphite2::json' and 'ptrdiff_t {aka long long int}')

Oh, and I think it's better to remove `json & operator << (integer) throw();` and all integer operators witch casts given number to json::integer, so proper (%hhd, %hhu, %hd, %hu, %d, %u, %ld, %lu) format specifiers can be used. The same with `inline json & operator << (json & j, char c) throw ()`
If you don't have any objections, tell me and I will add proper commit to this pull request.
