### PR TITLE
Build both shared and static library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,7 +65,7 @@ set(GRAPHITE_HEADERS
 
 file(GLOB PRIVATE_HEADERS inc/*.h) 
 
-add_library(graphite2 SHARED
+set(GRAPHITE_OBJECTS
     ${GRAPHITE2_VM_TYPE}_machine.cpp
     gr_char_info.cpp
     gr_features.cpp
@@ -98,6 +98,13 @@ add_library(graphite2 SHARED
     ${FILEFACE}
     ${SEGCACHE}
     ${TRACING})
+
+add_library(graphite2 SHARED ${GRAPHITE_OBJECTS})
+
+if(UNIX)
+add_library(graphite2static STATIC ${GRAPHITE_OBJECTS})
+set_target_properties(graphite2static PROPERTIES OUTPUT_NAME graphite2)
+endif()
 
 set_target_properties(graphite2 PROPERTIES  PUBLIC_HEADER "${GRAPHITE_HEADERS}"
                                             SOVERSION ${GRAPHITE_SO_VERSION}


### PR DESCRIPTION
This enabled building a static library, in addition to a shared one. Windows has a different linking system so this is only enabled for unix. References:

 - https://datainfer.wordpress.com/2013/10/24/make-both-static-and-shared-libraries-in-one-build-with-cmake/
 - https://stackoverflow.com/questions/2152077/is-it-possible-to-get-cmake-to-build-both-a-static-and-shared-version-of-the-sam

I need this myself for building standalone applications, but I think it is generally useful.

Thank you for your review!
