### PR TITLE
Cast to the proper base type when calling delete

### DIFF
--- a/src/gr_face.cpp
+++ b/src/gr_face.cpp
@@ -195,7 +195,7 @@ gr_uint32 gr_face_lang_by_index(const gr_face* pFace, gr_uint16 i)
 
 void gr_face_destroy(gr_face *face)
 {
-    delete face;
+    delete static_cast<Face*>(face);
 }
 
 

--- a/src/gr_features.cpp
+++ b/src/gr_features.cpp
@@ -131,7 +131,7 @@ gr_feature_val* gr_featureval_clone(const gr_feature_val* pfeatures/*may be NULL
   
 void gr_featureval_destroy(gr_feature_val *p)
 {
-    delete p;
+    delete static_cast<Features*>(p);
 }
 
 

--- a/src/gr_font.cpp
+++ b/src/gr_font.cpp
@@ -67,7 +67,7 @@ gr_font* gr_make_font_with_advance_fn(float ppm/*pixels per em*/, const void* ap
 
 void gr_font_destroy(gr_font *font)
 {
-    delete font;
+    delete static_cast<Font*>(font);
 }
 
 

--- a/src/gr_segment.cpp
+++ b/src/gr_segment.cpp
@@ -103,7 +103,7 @@ gr_segment* gr_make_seg(const gr_font *font, const gr_face *face, gr_uint32 scri
     if (pFeats == 0)
         pFeats = tmp_feats = static_cast<const gr_feature_val*>(face->theSill().cloneFeatures(0));
     gr_segment * seg = makeAndInitialize(font, face, script, pFeats, enc, pStart, nChars, dir);
-    delete tmp_feats;
+    delete static_cast<const FeatureVal*>(tmp_feats);
 
     return seg;
 }
@@ -111,7 +111,7 @@ gr_segment* gr_make_seg(const gr_font *font, const gr_face *face, gr_uint32 scri
 
 void gr_seg_destroy(gr_segment* p)
 {
-    delete p;
+    delete static_cast<Segment*>(p);
 }
 
 


### PR DESCRIPTION
It's not legitimate to call delete through a pointer whose (static) type
is a subclass of the actual (dynamic) type of the object.

See mozilla bug https://bugzilla.mozilla.org/show_bug.cgi?id=1442830.