### PR TITLE
Fix leak in FeatureMap

### DIFF
--- a/src/inc/FeatureMap.h
+++ b/src/inc/FeatureMap.h
@@ -118,7 +118,12 @@ class FeatureMap
 {
 public:
     FeatureMap() : m_numFeats(0), m_feats(NULL), m_pNamedFeats(NULL) {}
-    ~FeatureMap() { free(m_feats); delete[] m_pNamedFeats; }
+    ~FeatureMap() {
+      for (unsigned i = 0; i < m_numFeats; i++)
+        m_feats[i].~FeatureRef();
+      free(m_feats);
+      delete[] m_pNamedFeats;
+    }
 
     bool readFeats(const Face & face);
     const FeatureRef *findFeatureRef(uint32 name) const;


### PR DESCRIPTION
Just calling free(m_feats) in the FeatureMap destructor will not call
the destructors of the FeatureRef objects in the m_feats array,
with the result that their m_nameValues pointers don't get freed.
So we need to explicitly destroy the FeatureRefs here.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1443095.