### PR TITLE
Update definition of GR_FALLTHROUGH so it is more widely recognized

### DIFF
--- a/src/inc/Main.h
+++ b/src/inc/Main.h
@@ -172,9 +172,14 @@ inline T max(const T a, const T b)
 #define GR_MAYBE_UNUSED
 #endif
 
-#if defined(__clang__) && __cplusplus >= 201103L
-   /* clang's fallthrough annotations are only available starting in C++11. */
-    #define GR_FALLTHROUGH [[fallthrough]]
+#ifndef __has_cpp_attribute
+#  define __has_cpp_attribute(x) 0
+#endif
+
+#if __has_cpp_attribute(clang::fallthrough)
+#  define GR_FALLTHROUGH [[clang::fallthrough]]
+#elif __has_cpp_attribute(gnu::fallthrough)
+#  define GR_FALLTHROUGH [[gnu::fallthrough]]
 #elif defined(_MSC_VER)
    /*
     * MSVC's __fallthrough annotations are checked by /analyze (Code Analysis):


### PR DESCRIPTION
I noticed that in my local Mozilla build, the GR_FALLTHROUGH macro is not recognized (by compiler "Apple LLVM version 8.0.0 (clang-800.0.42.1)"), with the result that a bunch of unwanted warnings about fallthrough get generated.

Comparing how MOZ_FALLTHROUGH (used elsewhere in Gecko) is defined, I suggest a change such as this, which allows the annotation to be recognized by more compiler versions, and reduces noise in the build log.