### PR TITLE
Related: rhbz#1602527 CTOR_DTOR_LEAK coverity warning

### DIFF
--- a/src/GlyphCache.cpp
+++ b/src/GlyphCache.cpp
@@ -164,6 +164,10 @@ GlyphCache::GlyphCache(const Face & face, const uint32 face_options)
         }
         delete _glyph_loader;
         _glyph_loader = 0;
+	// coverity[leaked_storage : FALSE] - calling read_glyph on index 0 saved
+	// glyphs as _glyphs[0]. Setting _glyph_loader to nullptr here flags that
+	// the dtor needs to call delete[] on _glyphs[0] to release what was allocated
+	// as glyphs
     }
 
     if (_glyphs && glyph(0) == 0)

--- a/tests/comparerenderer/CompareRenderer.cpp
+++ b/tests/comparerenderer/CompareRenderer.cpp
@@ -371,6 +371,7 @@ int main(int argc, char ** argv)
     {
         fprintf(stderr, "Please specify at least 1 renderer\n");
         showOptions();
+        if (rendererOptions[OptLogFile].exists()) fclose(log);
         return -3;
     }
 

--- a/tests/featuremap/featuremaptest.cpp
+++ b/tests/featuremap/featuremaptest.cpp
@@ -187,6 +187,11 @@ public:
 	    _dir = _header + dir_off;
 	}
 
+	~face_handle()
+	{
+		delete [] _header;
+	}
+
 	void replace_table(const TtfUtil::Tag name, const void * const data, size_t len) throw() {
 		_tables[name] = std::make_pair(data, len);
 	}


### PR DESCRIPTION
tests/featuremap/featuremaptest.cpp:180: alloc_new: Allocating memory by calling "new char[font_size]".
tests/featuremap/featuremaptest.cpp:180: var_assign: Assigning: "this->_header" = "new char[font_size]".
tests/featuremap/featuremaptest.cpp:180: ctor_dtor_leak: The constructor allocates field "_header" of "face_handle" but there is no destructor.