### PR TITLE
Fix x32 being misdetected as amd64 in tests

### DIFF
--- a/tests/bittwiddling/bits.cpp
+++ b/tests/bittwiddling/bits.cpp
@@ -38,7 +38,7 @@ sparse classe is working correctly.
 
 using namespace graphite2;
 
-#if defined(__x86_64__) || defined(_WIN64)
+#if (defined(__x86_64__) && !defined(__ILP32__)) || defined(_WIN64)
 	#define HAS_64BIT
 #endif
 


### PR DESCRIPTION
x32 defines `__x86_64__` and `__ILP32__` and has 32-bit `long`s so it doesn’t work with the `UL` suffix in the test preparation.

Original bugreport: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=884190