### PR TITLE
CMake: Fix pkgconfig generation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,10 @@ if (NOT GRAPHITE2_NFILEFACE)
 endif()
 
 set(version 3.0.1)
+set(prefix ${CMAKE_INSTALL_PREFIX})
 set(libdir ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX})
 set(includedir ${CMAKE_INSTALL_PREFIX}/include)
 
-configure_file(graphite2.pc.in graphite2.pc)
+configure_file(graphite2.pc.in graphite2.pc @ONLY)
 
 install(FILES ${PROJECT_BINARY_DIR}/graphite2.pc DESTINATION lib${LIB_SUFFIX}/pkgconfig)

--- a/graphite2.pc.in
+++ b/graphite2.pc.in
@@ -1,7 +1,10 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
 
 Name: Graphite2
 Description: Font rendering engine for Complex Scripts
-Version: ${version}
+Version: @version@
 Libs: -L${libdir} -lgraphite2
 Cflags: -I${includedir}
-


### PR DESCRIPTION
Changes:
  * graphite.pc.in: Add prefix, exec_prefix, libdir, includedir variables.
  * graphite.pc.in: Use '@' for the variables which are to be replaced.
  * CMakeLists.txt: Add prefix variable to be set to CMAKE_INSTALL_PREFIX.
  * CMakeLists.txt: Add `@ONLY` argument in configure_file. So only variables
    which are prefixed with '@' will be replaced only. This helps to retain
    Libs and Cflags variables.