### PR TITLE
nametabletest.cpp: fix out-of-bounds access on endianness conversion

### DIFF
--- a/tests/nametabletest/nametabletest.cpp
+++ b/tests/nametabletest/nametabletest.cpp
@@ -137,7 +137,7 @@ template <class T> T * toBigEndian(T & table)
     bigEndian->m_nameHeader.count = be::swap<uint16>(table.m_nameHeader.count);
     bigEndian->m_nameHeader.string_offset = be::swap<uint16>(table.m_nameHeader.string_offset);
 
-    for (uint16 i = 0; i < table.m_nameHeader.count; i++)
+    for (uint16 i = 0; i < table.m_nameHeader.count - 1; i++)
     {
         bigEndian->m_records[i].platform_id = be::swap<uint16>(table.m_records[i].platform_id);
         bigEndian->m_records[i].platform_specific_id = be::swap<uint16>(table.m_records[i].platform_specific_id);


### PR DESCRIPTION
Initially observed as a `nametabletest` test failre on today's `gcc-13`. `-fsanitize=undefined` detected off-by-one error accessing one element past NameRecord array:

    $ ./tests/nametabletest/nametabletest
    tests/nametabletest/nametabletest.cpp:142:79: runtime error: index 5 out of bounds for type 'NameRecord [5]'
    ...
    tests/nametabletest/nametabletest.cpp:142:79: runtime error: index 7 out of bounds for type 'NameRecord [7]'
    ...

This happens because test record are slightly inconsistent: when name array has N entries N+1 is specified as count, and local `toBigEndian` helper uses this count to iterate over local array.

The rest of code (like `NameTable::getLanguageId`) seems to assume that table count is off-by-one.

The change fixes test failure on this week's `gcc-13`.