### PR TITLE
Relicenseing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.
+*.adoc text
 *.c text
 *.cfg text
 *.cpp text

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2010, SIL International, All rights reserved.
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
 cmake_policy(SET CMP0012 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.0 FATAL_ERROR)
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2010, SIL International, All rights reserved.
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
 cmake_policy(SET CMP0012 NEW)
 include(TestBigEndian)
 find_package(PythonInterp 3.6)

--- a/Graphite.cmake
+++ b/Graphite.cmake
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2011, SIL International, All rights reserved.
 include(GetPrerequisites)
 
 function(nolib_test LIBNAME OBJECTFILE)

--- a/Graphite.cmake
+++ b/Graphite.cmake
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2011, SIL International, All rights reserved.
 include(GetPrerequisites)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,510 +1,481 @@
-
-                  GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 2.1, February 1999
-
- Copyright (C) 1991, 1999 Free Software Foundation, Inc.
-	51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
-
-[This is the first released version of the Lesser GPL.  It also counts
- as the successor of the GNU Library Public License, version 2, hence
- the version number 2.1.]
-
-                            Preamble
-
-  The licenses for most software are designed to take away your
-freedom to share and change it.  By contrast, the GNU General Public
-Licenses are intended to guarantee your freedom to share and change
-free software--to make sure the software is free for all its users.
-
-  This license, the Lesser General Public License, applies to some
-specially designated software packages--typically libraries--of the
-Free Software Foundation and other authors who decide to use it.  You
-can use it too, but we suggest you first think carefully about whether
-this license or the ordinary General Public License is the better
-strategy to use in any particular case, based on the explanations
-below.
-
-  When we speak of free software, we are referring to freedom of use,
-not price.  Our General Public Licenses are designed to make sure that
-you have the freedom to distribute copies of free software (and charge
-for this service if you wish); that you receive source code or can get
-it if you want it; that you can change the software and use pieces of
-it in new free programs; and that you are informed that you can do
-these things.
-
-  To protect your rights, we need to make restrictions that forbid
-distributors to deny you these rights or to ask you to surrender these
-rights.  These restrictions translate to certain responsibilities for
-you if you distribute copies of the library or if you modify it.
-
-  For example, if you distribute copies of the library, whether gratis
-or for a fee, you must give the recipients all the rights that we gave
-you.  You must make sure that they, too, receive or can get the source
-code.  If you link other code with the library, you must provide
-complete object files to the recipients, so that they can relink them
-with the library after making changes to the library and recompiling
-it.  And you must show them these terms so they know their rights.
-
-  We protect your rights with a two-step method: (1) we copyright the
-library, and (2) we offer you this license, which gives you legal
-permission to copy, distribute and/or modify the library.
-
-  To protect each distributor, we want to make it very clear that
-there is no warranty for the free library.  Also, if the library is
-modified by someone else and passed on, the recipients should know
-that what they have is not the original version, so that the original
-author's reputation will not be affected by problems that might be
-introduced by others.
-
-  Finally, software patents pose a constant threat to the existence of
-any free program.  We wish to make sure that a company cannot
-effectively restrict the users of a free program by obtaining a
-restrictive license from a patent holder.  Therefore, we insist that
-any patent license obtained for a version of the library must be
-consistent with the full freedom of use specified in this license.
-
-  Most GNU software, including some libraries, is covered by the
-ordinary GNU General Public License.  This license, the GNU Lesser
-General Public License, applies to certain designated libraries, and
-is quite different from the ordinary General Public License.  We use
-this license for certain libraries in order to permit linking those
-libraries into non-free programs.
-
-  When a program is linked with a library, whether statically or using
-a shared library, the combination of the two is legally speaking a
-combined work, a derivative of the original library.  The ordinary
-General Public License therefore permits such linking only if the
-entire combination fits its criteria of freedom.  The Lesser General
-Public License permits more lax criteria for linking other code with
-the library.
-
-  We call this license the "Lesser" General Public License because it
-does Less to protect the user's freedom than the ordinary General
-Public License.  It also provides other free software developers Less
-of an advantage over competing non-free programs.  These disadvantages
-are the reason we use the ordinary General Public License for many
-libraries.  However, the Lesser license provides advantages in certain
-special circumstances.
-
-  For example, on rare occasions, there may be a special need to
-encourage the widest possible use of a certain library, so that it
-becomes a de-facto standard.  To achieve this, non-free programs must
-be allowed to use the library.  A more frequent case is that a free
-library does the same job as widely used non-free libraries.  In this
-case, there is little to gain by limiting the free library to free
-software only, so we use the Lesser General Public License.
-
-  In other cases, permission to use a particular library in non-free
-programs enables a greater number of people to use a large body of
-free software.  For example, permission to use the GNU C Library in
-non-free programs enables many more people to use the whole GNU
-operating system, as well as its variant, the GNU/Linux operating
-system.
-
-  Although the Lesser General Public License is Less protective of the
-users' freedom, it does ensure that the user of a program that is
-linked with the Library has the freedom and the wherewithal to run
-that program using a modified version of the Library.
-
-  The precise terms and conditions for copying, distribution and
-modification follow.  Pay close attention to the difference between a
-"work based on the library" and a "work that uses the library".  The
-former contains code derived from the library, whereas the latter must
-be combined with the library in order to run.
-
-                  GNU LESSER GENERAL PUBLIC LICENSE
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
-
-  0. This License Agreement applies to any software library or other
-program which contains a notice placed by the copyright holder or
-other authorized party saying it may be distributed under the terms of
-this Lesser General Public License (also called "this License").
-Each licensee is addressed as "you".
-
-  A "library" means a collection of software functions and/or data
-prepared so as to be conveniently linked with application programs
-(which use some of those functions and data) to form executables.
-
-  The "Library", below, refers to any such software library or work
-which has been distributed under these terms.  A "work based on the
-Library" means either the Library or any derivative work under
-copyright law: that is to say, a work containing the Library or a
-portion of it, either verbatim or with modifications and/or translated
-straightforwardly into another language.  (Hereinafter, translation is
-included without limitation in the term "modification".)
-
-  "Source code" for a work means the preferred form of the work for
-making modifications to it.  For a library, complete source code means
-all the source code for all modules it contains, plus any associated
-interface definition files, plus the scripts used to control
-compilation and installation of the library.
-
-  Activities other than copying, distribution and modification are not
-covered by this License; they are outside its scope.  The act of
-running a program using the Library is not restricted, and output from
-such a program is covered only if its contents constitute a work based
-on the Library (independent of the use of the Library in a tool for
-writing it).  Whether that is true depends on what the Library does
-and what the program that uses the Library does.
-
-  1. You may copy and distribute verbatim copies of the Library's
-complete source code as you receive it, in any medium, provided that
-you conspicuously and appropriately publish on each copy an
-appropriate copyright notice and disclaimer of warranty; keep intact
-all the notices that refer to this License and to the absence of any
-warranty; and distribute a copy of this License along with the
-Library.
-
-  You may charge a fee for the physical act of transferring a copy,
-and you may at your option offer warranty protection in exchange for a
-fee.
-
-  2. You may modify your copy or copies of the Library or any portion
-of it, thus forming a work based on the Library, and copy and
-distribute such modifications or work under the terms of Section 1
-above, provided that you also meet all of these conditions:
-
-    a) The modified work must itself be a software library.
-
-    b) You must cause the files modified to carry prominent notices
-    stating that you changed the files and the date of any change.
-
-    c) You must cause the whole of the work to be licensed at no
-    charge to all third parties under the terms of this License.
-
-    d) If a facility in the modified Library refers to a function or a
-    table of data to be supplied by an application program that uses
-    the facility, other than as an argument passed when the facility
-    is invoked, then you must make a good faith effort to ensure that,
-    in the event an application does not supply such function or
-    table, the facility still operates, and performs whatever part of
-    its purpose remains meaningful.
-
-    (For example, a function in a library to compute square roots has
-    a purpose that is entirely well-defined independent of the
-    application.  Therefore, Subsection 2d requires that any
-    application-supplied function or table used by this function must
-    be optional: if the application does not supply it, the square
-    root function must still compute square roots.)
-
-These requirements apply to the modified work as a whole.  If
-identifiable sections of that work are not derived from the Library,
-and can be reasonably considered independent and separate works in
-themselves, then this License, and its terms, do not apply to those
-sections when you distribute them as separate works.  But when you
-distribute the same sections as part of a whole which is a work based
-on the Library, the distribution of the whole must be on the terms of
-this License, whose permissions for other licensees extend to the
-entire whole, and thus to each and every part regardless of who wrote
-it.
-
-Thus, it is not the intent of this section to claim rights or contest
-your rights to work written entirely by you; rather, the intent is to
-exercise the right to control the distribution of derivative or
-collective works based on the Library.
-
-In addition, mere aggregation of another work not based on the Library
-with the Library (or with a work based on the Library) on a volume of
-a storage or distribution medium does not bring the other work under
-the scope of this License.
-
-  3. You may opt to apply the terms of the ordinary GNU General Public
-License instead of this License to a given copy of the Library.  To do
-this, you must alter all the notices that refer to this License, so
-that they refer to the ordinary GNU General Public License, version 2,
-instead of to this License.  (If a newer version than version 2 of the
-ordinary GNU General Public License has appeared, then you can specify
-that version instead if you wish.)  Do not make any other change in
-these notices.
-
-  Once this change is made in a given copy, it is irreversible for
-that copy, so the ordinary GNU General Public License applies to all
-subsequent copies and derivative works made from that copy.
-
-  This option is useful when you wish to copy part of the code of
-the Library into a program that is not a library.
-
-  4. You may copy and distribute the Library (or a portion or
-derivative of it, under Section 2) in object code or executable form
-under the terms of Sections 1 and 2 above provided that you accompany
-it with the complete corresponding machine-readable source code, which
-must be distributed under the terms of Sections 1 and 2 above on a
-medium customarily used for software interchange.
-
-  If distribution of object code is made by offering access to copy
-from a designated place, then offering equivalent access to copy the
-source code from the same place satisfies the requirement to
-distribute the source code, even though third parties are not
-compelled to copy the source along with the object code.
-
-  5. A program that contains no derivative of any portion of the
-Library, but is designed to work with the Library by being compiled or
-linked with it, is called a "work that uses the Library".  Such a
-work, in isolation, is not a derivative work of the Library, and
-therefore falls outside the scope of this License.
-
-  However, linking a "work that uses the Library" with the Library
-creates an executable that is a derivative of the Library (because it
-contains portions of the Library), rather than a "work that uses the
-library".  The executable is therefore covered by this License.
-Section 6 states terms for distribution of such executables.
-
-  When a "work that uses the Library" uses material from a header file
-that is part of the Library, the object code for the work may be a
-derivative work of the Library even though the source code is not.
-Whether this is true is especially significant if the work can be
-linked without the Library, or if the work is itself a library.  The
-threshold for this to be true is not precisely defined by law.
-
-  If such an object file uses only numerical parameters, data
-structure layouts and accessors, and small macros and small inline
-functions (ten lines or less in length), then the use of the object
-file is unrestricted, regardless of whether it is legally a derivative
-work.  (Executables containing this object code plus portions of the
-Library will still fall under Section 6.)
-
-  Otherwise, if the work is a derivative of the Library, you may
-distribute the object code for the work under the terms of Section 6.
-Any executables containing that work also fall under Section 6,
-whether or not they are linked directly with the Library itself.
-
-  6. As an exception to the Sections above, you may also combine or
-link a "work that uses the Library" with the Library to produce a
-work containing portions of the Library, and distribute that work
-under terms of your choice, provided that the terms permit
-modification of the work for the customer's own use and reverse
-engineering for debugging such modifications.
-
-  You must give prominent notice with each copy of the work that the
-Library is used in it and that the Library and its use are covered by
-this License.  You must supply a copy of this License.  If the work
-during execution displays copyright notices, you must include the
-copyright notice for the Library among them, as well as a reference
-directing the user to the copy of this License.  Also, you must do one
-of these things:
-
-    a) Accompany the work with the complete corresponding
-    machine-readable source code for the Library including whatever
-    changes were used in the work (which must be distributed under
-    Sections 1 and 2 above); and, if the work is an executable linked
-    with the Library, with the complete machine-readable "work that
-    uses the Library", as object code and/or source code, so that the
-    user can modify the Library and then relink to produce a modified
-    executable containing the modified Library.  (It is understood
-    that the user who changes the contents of definitions files in the
-    Library will not necessarily be able to recompile the application
-    to use the modified definitions.)
-
-    b) Use a suitable shared library mechanism for linking with the
-    Library.  A suitable mechanism is one that (1) uses at run time a
-    copy of the library already present on the user's computer system,
-    rather than copying library functions into the executable, and (2)
-    will operate properly with a modified version of the library, if
-    the user installs one, as long as the modified version is
-    interface-compatible with the version that the work was made with.
-
-    c) Accompany the work with a written offer, valid for at least
-    three years, to give the same user the materials specified in
-    Subsection 6a, above, for a charge no more than the cost of
-    performing this distribution.
-
-    d) If distribution of the work is made by offering access to copy
-    from a designated place, offer equivalent access to copy the above
-    specified materials from the same place.
-
-    e) Verify that the user has already received a copy of these
-    materials or that you have already sent this user a copy.
-
-  For an executable, the required form of the "work that uses the
-Library" must include any data and utility programs needed for
-reproducing the executable from it.  However, as a special exception,
-the materials to be distributed need not include anything that is
-normally distributed (in either source or binary form) with the major
-components (compiler, kernel, and so on) of the operating system on
-which the executable runs, unless that component itself accompanies
-the executable.
-
-  It may happen that this requirement contradicts the license
-restrictions of other proprietary libraries that do not normally
-accompany the operating system.  Such a contradiction means you cannot
-use both them and the Library together in an executable that you
-distribute.
-
-  7. You may place library facilities that are a work based on the
-Library side-by-side in a single library together with other library
-facilities not covered by this License, and distribute such a combined
-library, provided that the separate distribution of the work based on
-the Library and of the other library facilities is otherwise
-permitted, and provided that you do these two things:
-
-    a) Accompany the combined library with a copy of the same work
-    based on the Library, uncombined with any other library
-    facilities.  This must be distributed under the terms of the
-    Sections above.
-
-    b) Give prominent notice with the combined library of the fact
-    that part of it is a work based on the Library, and explaining
-    where to find the accompanying uncombined form of the same work.
-
-  8. You may not copy, modify, sublicense, link with, or distribute
-the Library except as expressly provided under this License.  Any
-attempt otherwise to copy, modify, sublicense, link with, or
-distribute the Library is void, and will automatically terminate your
-rights under this License.  However, parties who have received copies,
-or rights, from you under this License will not have their licenses
-terminated so long as such parties remain in full compliance.
-
-  9. You are not required to accept this License, since you have not
-signed it.  However, nothing else grants you permission to modify or
-distribute the Library or its derivative works.  These actions are
-prohibited by law if you do not accept this License.  Therefore, by
-modifying or distributing the Library (or any work based on the
-Library), you indicate your acceptance of this License to do so, and
-all its terms and conditions for copying, distributing or modifying
-the Library or works based on it.
-
-  10. Each time you redistribute the Library (or any work based on the
-Library), the recipient automatically receives a license from the
-original licensor to copy, distribute, link with or modify the Library
-subject to these terms and conditions.  You may not impose any further
-restrictions on the recipients' exercise of the rights granted herein.
-You are not responsible for enforcing compliance by third parties with
-this License.
-
-  11. If, as a consequence of a court judgment or allegation of patent
-infringement or for any other reason (not limited to patent issues),
-conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot
-distribute so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you
-may not distribute the Library at all.  For example, if a patent
-license would not permit royalty-free redistribution of the Library by
-all those who receive copies directly or indirectly through you, then
-the only way you could satisfy both it and this License would be to
-refrain entirely from distribution of the Library.
-
-If any portion of this section is held invalid or unenforceable under
-any particular circumstance, the balance of the section is intended to
-apply, and the section as a whole is intended to apply in other
-circumstances.
-
-It is not the purpose of this section to induce you to infringe any
-patents or other property right claims or to contest validity of any
-such claims; this section has the sole purpose of protecting the
-integrity of the free software distribution system which is
-implemented by public license practices.  Many people have made
-generous contributions to the wide range of software distributed
-through that system in reliance on consistent application of that
-system; it is up to the author/donor to decide if he or she is willing
-to distribute software through any other system and a licensee cannot
-impose that choice.
-
-This section is intended to make thoroughly clear what is believed to
-be a consequence of the rest of this License.
-
-  12. If the distribution and/or use of the Library is restricted in
-certain countries either by patents or by copyrighted interfaces, the
-original copyright holder who places the Library under this License
-may add an explicit geographical distribution limitation excluding those
-countries, so that distribution is permitted only in or among
-countries not thus excluded.  In such case, this License incorporates
-the limitation as if written in the body of this License.
-
-  13. The Free Software Foundation may publish revised and/or new
-versions of the Lesser General Public License from time to time.
-Such new versions will be similar in spirit to the present version,
-but may differ in detail to address new problems or concerns.
-
-Each version is given a distinguishing version number.  If the Library
-specifies a version number of this License which applies to it and
-"any later version", you have the option of following the terms and
-conditions either of that version or of any later version published by
-the Free Software Foundation.  If the Library does not specify a
-license version number, you may choose any version ever published by
-the Free Software Foundation.
-
-  14. If you wish to incorporate parts of the Library into other free
-programs whose distribution conditions are incompatible with these,
-write to the author to ask for permission.  For software which is
-copyrighted by the Free Software Foundation, write to the Free
-Software Foundation; we sometimes make exceptions for this.  Our
-decision will be guided by the two goals of preserving the free status
-of all derivatives of our free software and of promoting the sharing
-and reuse of software generally.
-
-                            NO WARRANTY
-
-  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
-WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
-EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
-OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
-KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
-LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
-THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-
-  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
-WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
-AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
-FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
-CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
-LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
-RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
-FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
-SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGES.
-
-                     END OF TERMS AND CONDITIONS
-
-           How to Apply These Terms to Your New Libraries
-
-  If you develop a new library, and you want it to be of the greatest
-possible use to the public, we recommend making it free software that
-everyone can redistribute and change.  You can do so by permitting
-redistribution under these terms (or, alternatively, under the terms
-of the ordinary General Public License).
-
-  To apply these terms, attach the following notices to the library.
-It is safest to attach them to the start of each source file to most
-effectively convey the exclusion of warranty; and each file should
-have at least the "copyright" line and a pointer to where the full
-notice is found.
-
-
-    <one line to give the library's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+Unless otherwise specified, source code and documentation aurthored, or
+copyrighted, by SIL International in this repository is simultaneously
+licensed under 4 licenses (LGPL-2.1+, MPL-2.0, GPL2+, or MIT) that you
+may chose to use at your descretion, these are listed below, in full where
+required, or referenced where not:
+
+--------------------------------------------------------------------------------
+                       GNU LESSER GENERAL PUBLIC LICENSE                        
+                          Version 2.1, February 1999                            
+
+Copyright (C) 1991, 1999 Free Software Foundation, Inc.  51 Franklin Street,
+Fifth Floor, Boston, MA 02110-1301 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license
+document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL. It also counts as the
+successor of the GNU Library Public License, version 2, hence the version
+number 2.1.]
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share
+and change it. By contrast, the GNU General Public Licenses are intended to
+guarantee your freedom to share and change free software--to make sure the
+software is free for all its users.
+
+This license, the Lesser General Public License, applies to some specially
+designated software packages--typically libraries--of the Free Software
+Foundation and other authors who decide to use it. You can use it too, but we
+suggest you first think carefully about whether this license or the ordinary
+General Public License is the better strategy to use in any particular case,
+based on the explanations below.
+
+When we speak of free software, we are referring to freedom of use, not
+price. Our General Public Licenses are designed to make sure that you have the
+freedom to distribute copies of free software (and charge for this service
+if you wish); that you receive source code or can get it if you want it;
+that you can change the software and use pieces of it in new free programs;
+and that you are informed that you can do these things.
+
+To protect your rights, we need to make restrictions that forbid distributors
+to deny you these rights or to ask you to surrender these rights. These
+restrictions translate to certain responsibilities for you if you distribute
+copies of the library or if you modify it.
+
+For example, if you distribute copies of the library, whether gratis or for
+a fee, you must give the recipients all the rights that we gave you. You
+must make sure that they, too, receive or can get the source code. If you
+link other code with the library, you must provide complete object files to
+the recipients, so that they can relink them with the library after making
+changes to the library and recompiling it. And you must show them these
+terms so they know their rights.
+
+We protect your rights with a two-step method: (1) we copyright the library,
+and (2) we offer you this license, which gives you legal permission to copy,
+distribute and/or modify the library.
+
+To protect each distributor, we want to make it very clear that there is no
+warranty for the free library. Also, if the library is modified by someone
+else and passed on, the recipients should know that what they have is not
+the original version, so that the original author's reputation will not be
+affected by problems that might be introduced by others.
+
+Finally, software patents pose a constant threat to the existence of any
+free program. We wish to make sure that a company cannot effectively restrict
+the users of a free program by obtaining a restrictive license from a patent
+holder. Therefore, we insist that any patent license obtained for a version
+of the library must be consistent with the full freedom of use specified in
+this license.
+
+Most GNU software, including some libraries, is covered by the ordinary GNU
+General Public License. This license, the GNU Lesser General Public License,
+applies to certain designated libraries, and is quite different from the
+ordinary General Public License. We use this license for certain libraries
+in order to permit linking those libraries into non-free programs.
+
+When a program is linked with a library, whether statically or using a
+shared library, the combination of the two is legally speaking a combined
+work, a derivative of the original library. The ordinary General Public
+License therefore permits such linking only if the entire combination fits
+its criteria of freedom. The Lesser General Public License permits more lax
+criteria for linking other code with the library.
+
+We call this license the "Lesser" General Public License because it does Less
+to protect the user's freedom than the ordinary General Public License. It
+also provides other free software developers Less of an advantage over
+competing non-free programs. These disadvantages are the reason we use the
+ordinary General Public License for many libraries. However, the Lesser
+license provides advantages in certain special circumstances.
+
+For example, on rare occasions, there may be a special need to encourage
+the widest possible use of a certain library, so that it becomes a de-facto
+standard. To achieve this, non-free programs must be allowed to use the
+library. A more frequent case is that a free library does the same job
+as widely used non-free libraries. In this case, there is little to gain
+by limiting the free library to free software only, so we use the Lesser
+General Public License.
+
+In other cases, permission to use a particular library in non-free programs
+enables a greater number of people to use a large body of free software. For
+example, permission to use the GNU C Library in non-free programs enables many
+more people to use the whole GNU operating system, as well as its variant,
+the GNU/Linux operating system.
+
+Although the Lesser General Public License is Less protective of the users'
+freedom, it does ensure that the user of a program that is linked with the
+Library has the freedom and the wherewithal to run that program using a
+modified version of the Library.
+
+The precise terms and conditions for copying, distribution and modification
+follow. Pay close attention to the difference between a "work based on the
+library" and a "work that uses the library". The former contains code derived
+from the library, whereas the latter must be combined with the library in
+order to run.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+    0. This License Agreement applies to any software library or other program
+    which contains a notice placed by the copyright holder or other authorized
+    party saying it may be distributed under the terms of this Lesser General
+    Public License (also called "this License"). Each licensee is addressed as
+    "you".
+
+    A "library" means a collection of software functions and/or data prepared
+    so as to be conveniently linked with application programs (which use
+    some of those functions and data) to form executables.
+
+    The "Library", below, refers to any such software library or work which
+    has been distributed under these terms. A "work based on the Library"
+    means either the Library or any derivative work under copyright law:
+    that is to say, a work containing the Library or a portion of it, either
+    verbatim or with modifications and/or translated straightforwardly into
+    another language. (Hereinafter, translation is included without limitation
+    in the term "modification".)
+
+    "Source code" for a work means the preferred form of the work for making
+    modifications to it. For a library, complete source code means all the
+    source code for all modules it contains, plus any associated interface
+    definition files, plus the scripts used to control compilation and
+    installation of the library.
+
+    Activities other than copying, distribution and modification are not
+    covered by this License; they are outside its scope. The act of running a
+    program using the Library is not restricted, and output from such a program
+    is covered only if its contents constitute a work based on the Library
+    (independent of the use of the Library in a tool for writing it). Whether
+    that is true depends on what the Library does and what the program that
+    uses the Library does.  1. You may copy and distribute verbatim copies
+    of the Library's complete source code as you receive it, in any medium,
+    provided that you conspicuously and appropriately publish on each copy
+    an appropriate copyright notice and disclaimer of warranty; keep intact
+    all the notices that refer to this License and to the absence of any
+    warranty; and distribute a copy of this License along with the Library.
+
+    You may charge a fee for the physical act of transferring a copy, and
+    you may at your option offer warranty protection in exchange for a fee.
+    2. You may modify your copy or copies of the Library or any portion of
+    it, thus forming a work based on the Library, and copy and distribute
+    such modifications or work under the terms of Section 1 above, provided
+    that you also meet all of these conditions:
+        a) The modified work must itself be a software library.  b) You must
+        cause the files modified to carry prominent notices stating that you
+        changed the files and the date of any change.  c) You must cause the
+        whole of the work to be licensed at no charge to all third parties
+        under the terms of this License.  d) If a facility in the modified
+        Library refers to a function or a table of data to be supplied by
+        an application program that uses the facility, other than as an
+        argument passed when the facility is invoked, then you must make a
+        good faith effort to ensure that, in the event an application does
+        not supply such function or table, the facility still operates,
+        and performs whatever part of its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has a purpose
+    that is entirely well-defined independent of the application. Therefore,
+    Subsection 2d requires that any application-supplied function or table
+    used by this function must be optional: if the application does not
+    supply it, the square root function must still compute square roots.)
+
+    These requirements apply to the modified work as a whole. If identifiable
+    sections of that work are not derived from the Library, and can be
+    reasonably considered independent and separate works in themselves,
+    then this License, and its terms, do not apply to those sections when
+    you distribute them as separate works. But when you distribute the same
+    sections as part of a whole which is a work based on the Library, the
+    distribution of the whole must be on the terms of this License, whose
+    permissions for other licensees extend to the entire whole, and thus to
+    each and every part regardless of who wrote it.
+
+    Thus, it is not the intent of this section to claim rights or contest your
+    rights to work written entirely by you; rather, the intent is to exercise
+    the right to control the distribution of derivative or collective works
+    based on the Library.
+
+    In addition, mere aggregation of another work not based on the Library
+    with the Library (or with a work based on the Library) on a volume of a
+    storage or distribution medium does not bring the other work under the
+    scope of this License.  3. You may opt to apply the terms of the ordinary
+    GNU General Public License instead of this License to a given copy of the
+    Library. To do this, you must alter all the notices that refer to this
+    License, so that they refer to the ordinary GNU General Public License,
+    version 2, instead of to this License. (If a newer version than version
+    2 of the ordinary GNU General Public License has appeared, then you can
+    specify that version instead if you wish.) Do not make any other change
+    in these notices.
+
+    Once this change is made in a given copy, it is irreversible for that
+    copy, so the ordinary GNU General Public License applies to all subsequent
+    copies and derivative works made from that copy.
+
+    This option is useful when you wish to copy part of the code of the Library
+    into a program that is not a library.  4. You may copy and distribute the
+    Library (or a portion or derivative of it, under Section 2) in object code
+    or executable form under the terms of Sections 1 and 2 above provided
+    that you accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections 1
+    and 2 above on a medium customarily used for software interchange.
+
+    If distribution of object code is made by offering access to copy from a
+    designated place, then offering equivalent access to copy the source code
+    from the same place satisfies the requirement to distribute the source
+    code, even though third parties are not compelled to copy the source
+    along with the object code.  5. A program that contains no derivative
+    of any portion of the Library, but is designed to work with the Library
+    by being compiled or linked with it, is called a "work that uses the
+    Library". Such a work, in isolation, is not a derivative work of the
+    Library, and therefore falls outside the scope of this License.
+
+    However, linking a "work that uses the Library" with the Library creates
+    an executable that is a derivative of the Library (because it contains
+    portions of the Library), rather than a "work that uses the library". The
+    executable is therefore covered by this License. Section 6 states terms
+    for distribution of such executables.
+
+    When a "work that uses the Library" uses material from a header file that
+    is part of the Library, the object code for the work may be a derivative
+    work of the Library even though the source code is not. Whether this
+    is true is especially significant if the work can be linked without the
+    Library, or if the work is itself a library. The threshold for this to
+    be true is not precisely defined by law.
+
+    If such an object file uses only numerical parameters, data structure
+    layouts and accessors, and small macros and small inline functions (ten
+    lines or less in length), then the use of the object file is unrestricted,
+    regardless of whether it is legally a derivative work. (Executables
+    containing this object code plus portions of the Library will still fall
+    under Section 6.)
+
+    Otherwise, if the work is a derivative of the Library, you may distribute
+    the object code for the work under the terms of Section 6. Any executables
+    containing that work also fall under Section 6, whether or not they
+    are linked directly with the Library itself.  6. As an exception to
+    the Sections above, you may also combine or link a "work that uses the
+    Library" with the Library to produce a work containing portions of the
+    Library, and distribute that work under terms of your choice, provided
+    that the terms permit modification of the work for the customer's own
+    use and reverse engineering for debugging such modifications.
+
+    You must give prominent notice with each copy of the work that the
+    Library is used in it and that the Library and its use are covered by
+    this License. You must supply a copy of this License. If the work during
+    execution displays copyright notices, you must include the copyright
+    notice for the Library among them, as well as a reference directing the
+    user to the copy of this License. Also, you must do one of these things:
+        a) Accompany the work with the complete corresponding machine-readable
+        source code for the Library including whatever changes were used in
+        the work (which must be distributed under Sections 1 and 2 above);
+        and, if the work is an executable linked with the Library, with the
+        complete machine-readable "work that uses the Library", as object
+        code and/or source code, so that the user can modify the Library and
+        then relink to produce a modified executable containing the modified
+        Library. (It is understood that the user who changes the contents
+        of definitions files in the Library will not necessarily be able to
+        recompile the application to use the modified definitions.)  b) Use
+        a suitable shared library mechanism for linking with the Library. A
+        suitable mechanism is one that (1) uses at run time a copy of the
+        library already present on the user's computer system, rather than
+        copying library functions into the executable, and (2) will operate
+        properly with a modified version of the library, if the user installs
+        one, as long as the modified version is interface-compatible with the
+        version that the work was made with.  c) Accompany the work with a
+        written offer, valid for at least three years, to give the same user
+        the materials specified in Subsection 6a, above, for a charge no more
+        than the cost of performing this distribution.  d) If distribution of
+        the work is made by offering access to copy from a designated place,
+        offer equivalent access to copy the above specified materials from
+        the same place.  e) Verify that the user has already received a copy
+        of these materials or that you have already sent this user a copy.
+
+    For an executable, the required form of the "work that uses the Library"
+    must include any data and utility programs needed for reproducing the
+    executable from it. However, as a special exception, the materials to
+    be distributed need not include anything that is normally distributed
+    (in either source or binary form) with the major components (compiler,
+    kernel, and so on) of the operating system on which the executable runs,
+    unless that component itself accompanies the executable.
+
+    It may happen that this requirement contradicts the license restrictions of
+    other proprietary libraries that do not normally accompany the operating
+    system. Such a contradiction means you cannot use both them and the
+    Library together in an executable that you distribute.  7. You may place
+    library facilities that are a work based on the Library side-by-side
+    in a single library together with other library facilities not covered
+    by this License, and distribute such a combined library, provided that
+    the separate distribution of the work based on the Library and of the
+    other library facilities is otherwise permitted, and provided that you
+    do these two things:
+        a) Accompany the combined library with a copy of the same work based
+        on the Library, uncombined with any other library facilities. This
+        must be distributed under the terms of the Sections above.  b) Give
+        prominent notice with the combined library of the fact that part of
+        it is a work based on the Library, and explaining where to find the
+        accompanying uncombined form of the same work.
+    8. You may not copy, modify, sublicense, link with, or distribute the
+    Library except as expressly provided under this License. Any attempt
+    otherwise to copy, modify, sublicense, link with, or distribute the
+    Library is void, and will automatically terminate your rights under
+    this License. However, parties who have received copies, or rights,
+    from you under this License will not have their licenses terminated
+    so long as such parties remain in full compliance.  9. You are not
+    required to accept this License, since you have not signed it. However,
+    nothing else grants you permission to modify or distribute the Library
+    or its derivative works. These actions are prohibited by law if you do
+    not accept this License. Therefore, by modifying or distributing the
+    Library (or any work based on the Library), you indicate your acceptance
+    of this License to do so, and all its terms and conditions for copying,
+    distributing or modifying the Library or works based on it.  10. Each
+    time you redistribute the Library (or any work based on the Library),
+    the recipient automatically receives a license from the original licensor
+    to copy, distribute, link with or modify the Library subject to these
+    terms and conditions. You may not impose any further restrictions on the
+    recipients' exercise of the rights granted herein. You are not responsible
+    for enforcing compliance by third parties with this License.  11. If, as
+    a consequence of a court judgment or allegation of patent infringement
+    or for any other reason (not limited to patent issues), conditions are
+    imposed on you (whether by court order, agreement or otherwise) that
+    contradict the conditions of this License, they do not excuse you from
+    the conditions of this License. If you cannot distribute so as to satisfy
+    simultaneously your obligations under this License and any other pertinent
+    obligations, then as a consequence you may not distribute the Library
+    at all. For example, if a patent license would not permit royalty-free
+    redistribution of the Library by all those who receive copies directly or
+    indirectly through you, then the only way you could satisfy both it and
+    this License would be to refrain entirely from distribution of the Library.
+
+    If any portion of this section is held invalid or unenforceable under any
+    particular circumstance, the balance of the section is intended to apply,
+    and the section as a whole is intended to apply in other circumstances.
+
+    It is not the purpose of this section to induce you to infringe any
+    patents or other property right claims or to contest validity of any such
+    claims; this section has the sole purpose of protecting the integrity
+    of the free software distribution system which is implemented by public
+    license practices. Many people have made generous contributions to the
+    wide range of software distributed through that system in reliance on
+    consistent application of that system; it is up to the author/donor to
+    decide if he or she is willing to distribute software through any other
+    system and a licensee cannot impose that choice.
+
+    This section is intended to make thoroughly clear what is believed to
+    be a consequence of the rest of this License.  12. If the distribution
+    and/or use of the Library is restricted in certain countries either by
+    patents or by copyrighted interfaces, the original copyright holder who
+    places the Library under this License may add an explicit geographical
+    distribution limitation excluding those countries, so that distribution
+    is permitted only in or among countries not thus excluded. In such case,
+    this License incorporates the limitation as if written in the body of
+    this License.  13. The Free Software Foundation may publish revised
+    and/or new versions of the Lesser General Public License from time to
+    time. Such new versions will be similar in spirit to the present version,
+    but may differ in detail to address new problems or concerns.
+
+    Each version is given a distinguishing version number. If the Library
+    specifies a version number of this License which applies to it and
+    "any later version", you have the option of following the terms and
+    conditions either of that version or of any later version published
+    by the Free Software Foundation. If the Library does not specify a
+    license version number, you may choose any version ever published by
+    the Free Software Foundation.  14. If you wish to incorporate parts of
+    the Library into other free programs whose distribution conditions are
+    incompatible with these, write to the author to ask for permission. For
+    software which is copyrighted by the Free Software Foundation, write to
+    the Free Software Foundation; we sometimes make exceptions for this. Our
+    decision will be guided by the two goals of preserving the free status
+    of all derivatives of our free software and of promoting the sharing
+    and reuse of software generally.
+
+    NO WARRANTY 15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE
+    IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE
+    LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS
+    AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF
+    ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+    THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+    PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY
+    IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF
+    ALL NECESSARY SERVICING, REPAIR OR CORRECTION.  16. IN NO EVENT UNLESS
+    REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT
+    HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY
+    AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL,
+    SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR
+    INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA
+    OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+    PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE),
+    EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY
+    OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Libraries
+
+If you develop a new library, and you want it to be of the greatest possible
+use to the public, we recommend making it free software that everyone can
+redistribute and change. You can do so by permitting redistribution under
+these terms (or, alternatively, under the terms of the ordinary General
+Public License).
+
+To apply these terms, attach the following notices to the library. It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+<one line to give the library's name and an idea of what it does.> Copyright
+(C) <year> <name of author>
+
+This library is free software; you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License as published by the Free
+Software Foundation; either version 2.1 of the License, or (at your option)
+any later version.
+
+This library is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this library; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Also add information on how to contact you by electronic and paper mail.
 
-You should also get your employer (if you work as a programmer) or
-your school, if any, to sign a "copyright disclaimer" for the library,
-if necessary.  Here is a sample; alter the names:
+You should also get your employer (if you work as a programmer) or your school,
+if any, to sign a "copyright disclaimer" for the library, if necessary. Here
+is a sample; alter the names:
 
-  Yoyodyne, Inc., hereby disclaims all copyright interest in the
-  library `Frob' (a library for tweaking knobs) written by James
-  Random Hacker.
+Yoyodyne, Inc., hereby disclaims all copyright interest in the library `Frob'
+(a library for tweaking knobs) written by James Random Hacker.
 
-  <signature of Ty Coon>, 1 April 1990
-  Ty Coon, President of Vice
+<signature of Ty Coon >, 1 April 1990 Ty Coon, President of Vice That's all
+there is to it!
 
-That's all there is to it!
+================================================================================
 
+                   Mozilla Public License Version 2.0 notice                    
 
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v. 2.0. If a copy of the MPL was not distributed with this file, You can
+obtain one at https://mozilla.org/MPL/2.0/.
+
+================================================================================
+
+                                  MIT License                                   
+
+Copyright (c) 2011-2022 SIL International
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/contrib/C#/NGraphite/AssemblyInfo.cs
+++ b/contrib/C#/NGraphite/AssemblyInfo.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System.Reflection;
 using System.Runtime.CompilerServices;
 

--- a/contrib/C#/NGraphite/AssemblyInfo.cs
+++ b/contrib/C#/NGraphite/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/contrib/C#/NGraphite/AttrCode.cs
+++ b/contrib/C#/NGraphite/AttrCode.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 

--- a/contrib/C#/NGraphite/AttrCode.cs
+++ b/contrib/C#/NGraphite/AttrCode.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 
 namespace NGraphite

--- a/contrib/C#/NGraphite/Bidirtl.cs
+++ b/contrib/C#/NGraphite/Bidirtl.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 

--- a/contrib/C#/NGraphite/Bidirtl.cs
+++ b/contrib/C#/NGraphite/Bidirtl.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 
 namespace NGraphite

--- a/contrib/C#/NGraphite/BreakWeight.cs
+++ b/contrib/C#/NGraphite/BreakWeight.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 

--- a/contrib/C#/NGraphite/BreakWeight.cs
+++ b/contrib/C#/NGraphite/BreakWeight.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 
 namespace NGraphite

--- a/contrib/C#/NGraphite/CharInfo.cs
+++ b/contrib/C#/NGraphite/CharInfo.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 

--- a/contrib/C#/NGraphite/CharInfo.cs
+++ b/contrib/C#/NGraphite/CharInfo.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 
 namespace NGraphite

--- a/contrib/C#/NGraphite/Encform.cs
+++ b/contrib/C#/NGraphite/Encform.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 

--- a/contrib/C#/NGraphite/Encform.cs
+++ b/contrib/C#/NGraphite/Encform.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 
 namespace NGraphite

--- a/contrib/C#/NGraphite/Face.cs
+++ b/contrib/C#/NGraphite/Face.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 using System.IO;
 

--- a/contrib/C#/NGraphite/Face.cs
+++ b/contrib/C#/NGraphite/Face.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 using System.IO;

--- a/contrib/C#/NGraphite/FaceOptions.cs
+++ b/contrib/C#/NGraphite/FaceOptions.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 namespace NGraphite
 {
 	public enum FaceOptions

--- a/contrib/C#/NGraphite/FaceOptions.cs
+++ b/contrib/C#/NGraphite/FaceOptions.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 namespace NGraphite
 {

--- a/contrib/C#/NGraphite/FeatureRef.cs
+++ b/contrib/C#/NGraphite/FeatureRef.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 using System.Runtime.InteropServices;

--- a/contrib/C#/NGraphite/FeatureRef.cs
+++ b/contrib/C#/NGraphite/FeatureRef.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 using System.Runtime.InteropServices;
 

--- a/contrib/C#/NGraphite/Featureval.cs
+++ b/contrib/C#/NGraphite/Featureval.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 

--- a/contrib/C#/NGraphite/Featureval.cs
+++ b/contrib/C#/NGraphite/Featureval.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 
 namespace NGraphite

--- a/contrib/C#/NGraphite/Font.cs
+++ b/contrib/C#/NGraphite/Font.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
  System;
 using System.Runtime.InteropServices;

--- a/contrib/C#/NGraphite/Font.cs
+++ b/contrib/C#/NGraphite/Font.cs
@@ -1,4 +1,6 @@
-using System;
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
+ System;
 using System.Runtime.InteropServices;
 
 namespace NGraphite

--- a/contrib/C#/NGraphite/Graphite2Api.cs
+++ b/contrib/C#/NGraphite/Graphite2Api.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/contrib/C#/NGraphite/Graphite2Api.cs
+++ b/contrib/C#/NGraphite/Graphite2Api.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 using System.Runtime.InteropServices;

--- a/contrib/C#/NGraphite/JustFlags.cs
+++ b/contrib/C#/NGraphite/JustFlags.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 

--- a/contrib/C#/NGraphite/JustFlags.cs
+++ b/contrib/C#/NGraphite/JustFlags.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 
 namespace NGraphite

--- a/contrib/C#/NGraphite/Segment.cs
+++ b/contrib/C#/NGraphite/Segment.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 

--- a/contrib/C#/NGraphite/Segment.cs
+++ b/contrib/C#/NGraphite/Segment.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 
 namespace NGraphite

--- a/contrib/C#/NGraphite/Slot.cs
+++ b/contrib/C#/NGraphite/Slot.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 

--- a/contrib/C#/NGraphite/Slot.cs
+++ b/contrib/C#/NGraphite/Slot.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 
 namespace NGraphite

--- a/contrib/C#/NGraphiteTests/CharInfoTests.cs
+++ b/contrib/C#/NGraphiteTests/CharInfoTests.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;

--- a/contrib/C#/NGraphiteTests/CharInfoTests.cs
+++ b/contrib/C#/NGraphiteTests/CharInfoTests.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;
 using NGraphite;

--- a/contrib/C#/NGraphiteTests/FaceTests.cs
+++ b/contrib/C#/NGraphiteTests/FaceTests.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;

--- a/contrib/C#/NGraphiteTests/FaceTests.cs
+++ b/contrib/C#/NGraphiteTests/FaceTests.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;
 using NGraphite;

--- a/contrib/C#/NGraphiteTests/FeatureRefTests.cs
+++ b/contrib/C#/NGraphiteTests/FeatureRefTests.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;

--- a/contrib/C#/NGraphiteTests/FeatureRefTests.cs
+++ b/contrib/C#/NGraphiteTests/FeatureRefTests.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;
 using NGraphite;

--- a/contrib/C#/NGraphiteTests/FeaturevalTests.cs
+++ b/contrib/C#/NGraphiteTests/FeaturevalTests.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;

--- a/contrib/C#/NGraphiteTests/FeaturevalTests.cs
+++ b/contrib/C#/NGraphiteTests/FeaturevalTests.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;
 using NGraphite;

--- a/contrib/C#/NGraphiteTests/FontTests.cs
+++ b/contrib/C#/NGraphiteTests/FontTests.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;

--- a/contrib/C#/NGraphiteTests/FontTests.cs
+++ b/contrib/C#/NGraphiteTests/FontTests.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;
 using NGraphite;

--- a/contrib/C#/NGraphiteTests/GeneralTests.cs
+++ b/contrib/C#/NGraphiteTests/GeneralTests.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using NUnit.Framework;
 using NGraphite;

--- a/contrib/C#/NGraphiteTests/GeneralTests.cs
+++ b/contrib/C#/NGraphiteTests/GeneralTests.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using NUnit.Framework;
 using NGraphite;
 using System.Collections.Generic;

--- a/contrib/C#/NGraphiteTests/Graphite2ApiTests.cs
+++ b/contrib/C#/NGraphiteTests/Graphite2ApiTests.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;

--- a/contrib/C#/NGraphiteTests/Graphite2ApiTests.cs
+++ b/contrib/C#/NGraphiteTests/Graphite2ApiTests.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;
 using NGraphite;

--- a/contrib/C#/NGraphiteTests/SegmentTests.cs
+++ b/contrib/C#/NGraphiteTests/SegmentTests.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;

--- a/contrib/C#/NGraphiteTests/SegmentTests.cs
+++ b/contrib/C#/NGraphiteTests/SegmentTests.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;
 using NGraphite;

--- a/contrib/C#/NGraphiteTests/SlotTests.cs
+++ b/contrib/C#/NGraphiteTests/SlotTests.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;

--- a/contrib/C#/NGraphiteTests/SlotTests.cs
+++ b/contrib/C#/NGraphiteTests/SlotTests.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;
 using NGraphite;

--- a/contrib/C#/NGraphiteTests/TestConstants.cs
+++ b/contrib/C#/NGraphiteTests/TestConstants.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;

--- a/contrib/C#/NGraphiteTests/TestConstants.cs
+++ b/contrib/C#/NGraphiteTests/TestConstants.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
 using System;
 using NUnit.Framework;
 using NGraphite;

--- a/contrib/perl/Build.PL
+++ b/contrib/perl/Build.PL
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Artistic-1.0-Perl
+# Copyright (C) 2011 Simon Cozens
 use strict;
 use warnings;
 use Module::Build;

--- a/contrib/perl/examples/gr2fonttest.pl
+++ b/contrib/perl/examples/gr2fonttest.pl
@@ -1,4 +1,6 @@
 #!/usr/bin/perl
+# SPDX-License-Identifier: Artistic-1.0-Perl
+# Copyright (C) 2011 Simon Cozens
 use Encode qw/encode/;
     $SIG{__WARN__} = sub {
         CORE::dump if $_[0] =~ /uninitialized value in subroutine entry/;

--- a/contrib/perl/examples/typeset.pl
+++ b/contrib/perl/examples/typeset.pl
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Artistic-1.0-Perl
+# Copyright (C) 2011 Simon Cozens
 use PDF::API2;
 use Text::Gr2;
 use File::Slurp;

--- a/contrib/perl/lib/Text/Gr2.pm
+++ b/contrib/perl/lib/Text/Gr2.pm
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Artistic-1.0-Perl
+# Copyright 2011, Simon Cozens & SIL International, All rights reserved.
 package Text::Gr2;
 use Text::Gr2::Face;
 use Text::Gr2::Font;
@@ -91,31 +93,8 @@ __END__
 
 =begin copyright
 
-GRAPHITE2 LICENSING
-
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
+ SPDX-License-Identifier: Artistic-1.0-Perl
+ Copyright 2011, Simon Cozens & SIL International, All rights reserved.
 
     Author: Simon Cozens <simon@cpan.org>
 

--- a/contrib/perl/lib/Text/Gr2.xs
+++ b/contrib/perl/lib/Text/Gr2.xs
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Artistic-1.0-Perl
+   Copyright (C) 2011 Simon Cozens */
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"

--- a/contrib/perl/lib/Text/Gr2/CharInfo.pm
+++ b/contrib/perl/lib/Text/Gr2/CharInfo.pm
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Artistic-1.0-Perl
+# Copyright (C) 2011 Simon Cozens
 =head1 NAME
 
 Text::Gr2::CharInfo - Character information

--- a/contrib/perl/lib/Text/Gr2/Face.pm
+++ b/contrib/perl/lib/Text/Gr2/Face.pm
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Artistic-1.0-Perl
+# Copyright (C) 2011 Simon Cozens
 package Text::Gr2::Face;
 
 =head1 NAME

--- a/contrib/perl/lib/Text/Gr2/FeatureRef.pm
+++ b/contrib/perl/lib/Text/Gr2/FeatureRef.pm
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Artistic-1.0-Perl
+# Copyright (C) 2011 Simon Cozens
 package Text::Gr2::FeatureRef;
 
 =head1 NAME

--- a/contrib/perl/lib/Text/Gr2/FeatureVal.pm
+++ b/contrib/perl/lib/Text/Gr2/FeatureVal.pm
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Artistic-1.0-Perl
+# Copyright (C) 2011 Simon Cozens
 =head1 NAME
 
 Text::Gr2::FeatureVal - values for a feature

--- a/contrib/perl/lib/Text/Gr2/Font.pm
+++ b/contrib/perl/lib/Text/Gr2/Font.pm
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Artistic-1.0-Perl
+# Copyright (C) 2011 Simon Cozens
 package Text::Gr2::Font;
 use strict;
 no bytes;

--- a/contrib/perl/lib/Text/Gr2/Segment.pm
+++ b/contrib/perl/lib/Text/Gr2/Segment.pm
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Artistic-1.0-Perl
+# Copyright (C) 2011 Simon Cozens
 package Text::Gr2::Segment;
 
 =head1 NAME

--- a/contrib/perl/lib/Text/Gr2/Slot.pm
+++ b/contrib/perl/lib/Text/Gr2/Slot.pm
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Artistic-1.0-Perl
+# Copyright (C) 2011 Simon Cozens
 =head1 NAME
 
 Text::Gr2::Slot - Represents a slot within a segment

--- a/contrib/perl/lib/Text/typemap
+++ b/contrib/perl/lib/Text/typemap
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Artistic-1.0-Perl
 ###############################################################################
 ##
 ##    Typemap for Graphite2 objects

--- a/contrib/perl/t/00-load.t
+++ b/contrib/perl/t/00-load.t
@@ -1,4 +1,6 @@
 #!perl -T
+# SPDX-License-Identifier: Artistic-1.0-Perl
+# Copyright (C) 2011 Simon Cozens
 
 use Test::More tests => 1;
 

--- a/contrib/perl/t/pod-coverage.t
+++ b/contrib/perl/t/pod-coverage.t
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Artistic-1.0-Perl
+# Copyright (C) 2011 Simon Cozens
 use strict;
 use warnings;
 use Test::More;

--- a/contrib/perl/t/pod.t
+++ b/contrib/perl/t/pod.t
@@ -1,4 +1,6 @@
 #!perl -T
+# SPDX-License-Identifier: Artistic-1.0-Perl
+# Copyright (C) 2011 Simon Cozens
 
 use strict;
 use warnings;

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2010, SIL International, All rights reserved.
 project(docs)
 
 set(GRAPHITE2_DOXYGEN_CONFIG public CACHE STRING "Specifies the base configuration file for doxygen. Current values: public, all")
@@ -11,7 +13,14 @@ set(DOC_DEPENDS)
 if(A2X)
     if(DBLATEX)
         add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/manual.pdf
-                           DEPENDS ${PROJECT_SOURCE_DIR}/[a-z]*.adoc
+                           DEPENDS ${PROJECT_SOURCE_DIR}/manual.adoc
+                                   ${PROJECT_SOURCE_DIR}/intro.adoc
+                                   ${PROJECT_SOURCE_DIR}/building.adoc
+                                   ${PROJECT_SOURCE_DIR}/calling.adoc
+                                   ${PROJECT_SOURCE_DIR}/features.adoc
+                                   ${PROJECT_SOURCE_DIR}/font.adoc
+                                   ${PROJECT_SOURCE_DIR}/hacking.adoc
+                                   ${PROJECT_SOURCE_DIR}/testing.adoc
                            COMMAND ${A2X} --icons -D ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/manual.adoc)
         add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/GTF.pdf
                            DEPENDS ${PROJECT_SOURCE_DIR}/GTF.adoc
@@ -20,7 +29,15 @@ if(A2X)
         set(DOC_DEPENDS ${PROJECT_BINARY_DIR}/manual.pdf ${PROJECT_BINARY_DIR}/GTF.pdf)
     endif()
     add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/manual.html
-                       DEPENDS ${PROJECT_SOURCE_DIR}/[a-z]*.adoc ${PROJECT_SOURCE_DIR}/graphite.css
+                       DEPENDS ${PROJECT_SOURCE_DIR}/manual.adoc
+                               ${PROJECT_SOURCE_DIR}/intro.adoc
+                               ${PROJECT_SOURCE_DIR}/building.adoc
+                               ${PROJECT_SOURCE_DIR}/calling.adoc
+                               ${PROJECT_SOURCE_DIR}/features.adoc
+                               ${PROJECT_SOURCE_DIR}/font.adoc
+                               ${PROJECT_SOURCE_DIR}/hacking.adoc
+                               ${PROJECT_SOURCE_DIR}/testing.adoc
+                               ${PROJECT_SOURCE_DIR}/graphite.css
                        COMMAND ${A2X} -f xhtml --stylesheet=graphite.css -D ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/manual.adoc)
     add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/GTF.html
                        DEPENDS ${PROJECT_SOURCE_DIR}/GTF.adoc

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2010, SIL International, All rights reserved.
 project(docs)
 

--- a/doc/GTF.adoc
+++ b/doc/GTF.adoc
@@ -840,4 +840,4 @@ description override the corresponding font table in the font, means that a name
 table in an external binary description must be complete, including all the
 strings from the original font.
 
-include::OpCodes.txt[]
+include::OpCodes.adoc[]

--- a/doc/OpCodes.adoc
+++ b/doc/OpCodes.adoc
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+﻿// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 == Stack Machine Commands ==
 

--- a/doc/OpCodes.adoc
+++ b/doc/OpCodes.adoc
@@ -1,4 +1,6 @@
-﻿== Stack Machine Commands ==
+﻿// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
+== Stack Machine Commands ==
 
 This document describes the commands that are defined in Graphite’s stack
 machine, which are used to run rules and test their constraints. By default

--- a/doc/building.adoc
+++ b/doc/building.adoc
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 == Building Graphite 2 ==
 
 Graphite 2 is made available as a source tarball from these urls:

--- a/doc/building.adoc
+++ b/doc/building.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 == Building Graphite 2 ==
 

--- a/doc/calling.adoc
+++ b/doc/calling.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 == Calling Graphite2 ==
 

--- a/doc/calling.adoc
+++ b/doc/calling.adoc
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 == Calling Graphite2 ==
 
 === Introduction ===

--- a/doc/features.adoc
+++ b/doc/features.adoc
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 == Font Features ==
 
 Graphite fonts have user features. These are values that can be set to control

--- a/doc/features.adoc
+++ b/doc/features.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 == Font Features ==
 

--- a/doc/font.adoc
+++ b/doc/font.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 == Font Topics ==
 

--- a/doc/font.adoc
+++ b/doc/font.adoc
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 == Font Topics ==
 
 === Guard Space ===

--- a/doc/hacking.adoc
+++ b/doc/hacking.adoc
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 == Hacking ==
 
 In this section we look at coding conventions and some of the design models used

--- a/doc/hacking.adoc
+++ b/doc/hacking.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 == Hacking ==
 

--- a/doc/intro.adoc
+++ b/doc/intro.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 == Introduction ==
 

--- a/doc/intro.adoc
+++ b/doc/intro.adoc
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 == Introduction ==
 
 Graphite2 is a reimplementation of the SIL Graphite text processing engine. The

--- a/doc/manual.adoc
+++ b/doc/manual.adoc
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 = Graphite2 Manual =
 Martin Hosken <martin_hosken@sil.org>
 

--- a/doc/manual.adoc
+++ b/doc/manual.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 = Graphite2 Manual =
 Martin Hosken <martin_hosken@sil.org>

--- a/doc/release.adoc
+++ b/doc/release.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 == Release Process ==
 

--- a/doc/release.adoc
+++ b/doc/release.adoc
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 == Release Process ==
 
 These notes are not necessarily part of the manual. They are here for code

--- a/doc/testing.adoc
+++ b/doc/testing.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 == Testing Graphite2 ==
 

--- a/doc/testing.adoc
+++ b/doc/testing.adoc
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 == Testing Graphite2 ==
 
 During development Graphite2 is regularly checked against its test suite of over

--- a/gr2fonttest/CMakeLists.txt
+++ b/gr2fonttest/CMakeLists.txt
@@ -1,4 +1,6 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.0 FATAL_ERROR)
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2010, SIL International, All rights reserved.
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
 
 project(gr2fonttest)
 

--- a/gr2fonttest/CMakeLists.txt
+++ b/gr2fonttest/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2010, SIL International, All rights reserved.
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
 

--- a/gr2fonttest/UtfCodec.cpp
+++ b/gr2fonttest/UtfCodec.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include "UtfCodec.h"

--- a/gr2fonttest/UtfCodec.cpp
+++ b/gr2fonttest/UtfCodec.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include "UtfCodec.h"
 //using namespace graphite2;
 

--- a/gr2fonttest/UtfCodec.h
+++ b/gr2fonttest/UtfCodec.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 #include <cstdlib>

--- a/gr2fonttest/UtfCodec.h
+++ b/gr2fonttest/UtfCodec.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/gr2fonttest/gr2FontTest.cpp
+++ b/gr2fonttest/gr2FontTest.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2005 www.thanlwinsoft.org, SIL International
 /*
 Responsibility: Keith Stribley, Martin Hosken

--- a/gr2fonttest/gr2FontTest.cpp
+++ b/gr2fonttest/gr2FontTest.cpp
@@ -1,34 +1,13 @@
-/*-----------------------------------------------------------------------------
-Copyright (C) 2005 www.thanlwinsoft.org, SIL International
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2005 www.thanlwinsoft.org, SIL International
+/*
 Responsibility: Keith Stribley, Martin Hosken
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-
 Description:
 A simple console app that creates a segment using FileFont and dumps a
 diagnostic table of the resulting glyph vector to the console.
 If graphite has been built with -DTRACING then it will also produce a
 diagnostic log of the segment creation in grSegmentLog.txt
------------------------------------------------------------------------------*/
+*/
 
 #include <cstdio>
 #include <cstdlib>

--- a/include/graphite2/Font.h
+++ b/include/graphite2/Font.h
@@ -1,29 +1,5 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-    Alternatively, the contents of this file may be used under the terms
-    of the Mozilla Public License (http://mozilla.org/MPL) or the GNU
-    General Public License, as published by the Free Software Foundation,
-    either version 2 of the License or (at your option) any later version.
-*/
+/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* Copyright 2010, SIL International, All rights reserved. */
 #pragma once
 
 #include "graphite2/Types.h"

--- a/include/graphite2/Font.h
+++ b/include/graphite2/Font.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later */
 /* Copyright 2010, SIL International, All rights reserved. */
 #pragma once
 

--- a/include/graphite2/Log.h
+++ b/include/graphite2/Log.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later */
 /* Copyright 2010, SIL International, All rights reserved. */
 #pragma once
 

--- a/include/graphite2/Log.h
+++ b/include/graphite2/Log.h
@@ -1,29 +1,5 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-    Alternatively, the contents of this file may be used under the terms
-    of the Mozilla Public License (http://mozilla.org/MPL) or the GNU
-    General Public License, as published by the Free Software Foundation,
-    either version 2 of the License or (at your option) any later version.
-*/
+/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* Copyright 2010, SIL International, All rights reserved. */
 #pragma once
 
 #include <graphite2/Types.h>

--- a/include/graphite2/Segment.h
+++ b/include/graphite2/Segment.h
@@ -1,29 +1,5 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-    Alternatively, the contents of this file may be used under the terms
-    of the Mozilla Public License (http://mozilla.org/MPL) or the GNU
-    General Public License, as published by the Free Software Foundation,
-    either version 2 of the License or (at your option) any later version.
-*/
+/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* Copyright 2010, SIL International, All rights reserved. */
 #pragma once
 
 #include "graphite2/Types.h"

--- a/include/graphite2/Segment.h
+++ b/include/graphite2/Segment.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later */
 /* Copyright 2010, SIL International, All rights reserved. */
 #pragma once
 

--- a/include/graphite2/Types.h
+++ b/include/graphite2/Types.h
@@ -1,29 +1,5 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-    Alternatively, the contents of this file may be used under the terms
-    of the Mozilla Public License (http://mozilla.org/MPL) or the GNU
-    General Public License, as published by the Free Software Foundation,
-    either version 2 of the License or (at your option) any later version.
-*/
+/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* Copyright 2010, SIL International, All rights reserved. */
 #pragma once
 
 #include <stddef.h>

--- a/include/graphite2/Types.h
+++ b/include/graphite2/Types.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later */
 /* Copyright 2010, SIL International, All rights reserved. */
 #pragma once
 

--- a/python/fuzzbidi.py
+++ b/python/fuzzbidi.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright (C) 2013 SIL International
 import graphite2
 import itertools
 import math

--- a/python/fuzzbidi.py
+++ b/python/fuzzbidi.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright (C) 2013 SIL International
 import graphite2
 import itertools

--- a/python/graphite2/__init__.py
+++ b/python/graphite2/__init__.py
@@ -1,22 +1,5 @@
-#    Copyright 2012, SIL International
-#    All rights reserved.
-#
-#    This library is free software; you can redistribute it and/or modify
-#    it under the terms of the GNU Lesser General Public License as published
-#    by the Free Software Foundation; either version 2.1 of License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-#    Lesser General Public License for more details.
-#
-#    You should also have received a copy of the GNU Lesser General Public
-#    License along with this library in the file named "LICENSE".
-#    If not, write to the Free Software Foundation, 51 Franklin Street,
-#    suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-#    internet at http://www.fsf.org/licenses/lgpl.html.
-
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Copyright 2013, SIL International, All rights reserved.
 import ctypes
 import ctypes.util
 import errno

--- a/python/graphite2/__init__.py
+++ b/python/graphite2/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR GPL-2.0-or-later-2.1-or-later
 # Copyright 2013, SIL International, All rights reserved.
 import ctypes
 import ctypes.util

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2018, SIL International, All rights reserved.
 
 from re import findall

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2018, SIL International, All rights reserved.
 
 from re import findall
 from os import path
@@ -21,7 +23,7 @@ setup(
     version          = version,
     description      = 'SIL graphite2 smart font system python bindings',
     author           = 'SIL International',
-    license          = 'LGPL-2.1+ OR MPL-1.1+',
+    license          = 'LGPL-2.1+ OR MPL-2.0 OR GPL-2+',
     url              = 'https://github.com/silnrsi/graphite',
     zip_safe         = False,
     package_dir      = {'': 'python'},
@@ -30,8 +32,9 @@ setup(
     long_description = long_description,
     long_description_content_type = 'text/markdown',
     classifiers = [
-        'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
-        'License :: OSI Approved :: Mozilla Public License 1.1 (MPL 1.1)',
+        'License :: OSI Approved :: GNU Library or Lesser General Public License v2 or later (LGPLv2+)',
+        'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
+        'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Programming Language :: Python :: 2.7',

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2010, SIL International, All rights reserved.
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
 project(graphite2_core)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,25 +1,6 @@
-#    GRAPHITE2 LICENSING
-#
-#    Copyright 2010, SIL International
-#    All rights reserved.
-#
-#    This library is free software; you can redistribute it and/or modify
-#    it under the terms of the GNU Lesser General Public License as published
-#    by the Free Software Foundation; either version 2.1 of License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-#    Lesser General Public License for more details.
-#
-#    You should also have received a copy of the GNU Lesser General Public
-#    License along with this library in the file named "LICENSE".
-#    If not, write to the Free Software Foundation, 51 Franklin Street,
-#    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-#    internet at http://www.fsf.org/licenses/lgpl.html.
-
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.0 FATAL_ERROR)
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2010, SIL International, All rights reserved.
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
 project(graphite2_core)
 cmake_policy(SET CMP0012 NEW)
 INCLUDE(CheckCXXSourceCompiles)

--- a/src/CmapCache.cpp
+++ b/src/CmapCache.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 
 #include "inc/Main.h"
 #include "inc/CmapCache.h"

--- a/src/CmapCache.cpp
+++ b/src/CmapCache.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 

--- a/src/Code.cpp
+++ b/src/Code.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 // This class represents loaded graphite stack machine code.  It performs
 // basic sanity checks, on the incoming code to prevent more obvious problems
 // from crashing graphite.

--- a/src/Code.cpp
+++ b/src/Code.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 // This class represents loaded graphite stack machine code.  It performs

--- a/src/Collider.cpp
+++ b/src/Collider.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include <algorithm>
 #include <limits>
 #include <cmath>

--- a/src/Collider.cpp
+++ b/src/Collider.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include <algorithm>

--- a/src/Decompressor.cpp
+++ b/src/Decompressor.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2015, SIL International, All rights reserved.
 
-    Copyright 2015, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include <cassert>
 
 #include "inc/Decompressor.h"

--- a/src/Decompressor.cpp
+++ b/src/Decompressor.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2015, SIL International, All rights reserved.
 
 #include <cassert>

--- a/src/Face.cpp
+++ b/src/Face.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include <cstring>
 #include "graphite2/Segment.h"
 #include "inc/CmapCache.h"

--- a/src/Face.cpp
+++ b/src/Face.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include <cstring>

--- a/src/FeatureMap.cpp
+++ b/src/FeatureMap.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include <cstring>
 
 #include "inc/Main.h"

--- a/src/FeatureMap.cpp
+++ b/src/FeatureMap.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include <cstring>

--- a/src/FileFace.cpp
+++ b/src/FileFace.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2012, SIL International, All rights reserved.
 
-    Copyright 2012, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include <cstring>
 #include "inc/FileFace.h"
 

--- a/src/FileFace.cpp
+++ b/src/FileFace.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2012, SIL International, All rights reserved.
 
 #include <cstring>

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include "inc/Face.h"

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include "inc/Face.h"
 #include "inc/Font.h"
 #include "inc/GlyphCache.h"

--- a/src/GlyphCache.cpp
+++ b/src/GlyphCache.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2012, SIL International, All rights reserved.
 
-    Copyright 2012, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include "graphite2/Font.h"
 
 #include "inc/Main.h"

--- a/src/GlyphCache.cpp
+++ b/src/GlyphCache.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2012, SIL International, All rights reserved.
 
 #include "graphite2/Font.h"

--- a/src/GlyphFace.cpp
+++ b/src/GlyphFace.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include "inc/GlyphFace.h"
 
 

--- a/src/GlyphFace.cpp
+++ b/src/GlyphFace.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include "inc/GlyphFace.h"

--- a/src/Intervals.cpp
+++ b/src/Intervals.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include <algorithm>
 #include <cmath>
 #include <limits>

--- a/src/Intervals.cpp
+++ b/src/Intervals.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include <algorithm>

--- a/src/Justifier.cpp
+++ b/src/Justifier.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2012, SIL International, All rights reserved.
 
-    Copyright 2012, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 
 #include "inc/Segment.h"
 #include "graphite2/Font.h"

--- a/src/Justifier.cpp
+++ b/src/Justifier.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2012, SIL International, All rights reserved.
 
 

--- a/src/NameTable.cpp
+++ b/src/NameTable.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include "inc/Main.h"
 #include "inc/Endian.h"
 

--- a/src/NameTable.cpp
+++ b/src/NameTable.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include "inc/Main.h"

--- a/src/Pass.cpp
+++ b/src/Pass.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include "inc/Main.h"
 #include "inc/debug.h"
 #include "inc/Endian.h"

--- a/src/Pass.cpp
+++ b/src/Pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include "inc/Main.h"

--- a/src/Position.cpp
+++ b/src/Position.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include "inc/Position.h"

--- a/src/Position.cpp
+++ b/src/Position.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include "inc/Position.h"
 #include <cmath>
 

--- a/src/Segment.cpp
+++ b/src/Segment.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include "inc/UtfCodec.h"
 #include <cstring>
 #include <cstdlib>

--- a/src/Segment.cpp
+++ b/src/Segment.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include "inc/UtfCodec.h"

--- a/src/Silf.cpp
+++ b/src/Silf.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include <cstdlib>
 #include "graphite2/Segment.h"
 #include "inc/debug.h"

--- a/src/Silf.cpp
+++ b/src/Silf.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include <cstdlib>

--- a/src/Slot.cpp
+++ b/src/Slot.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include "inc/Segment.h"

--- a/src/Slot.cpp
+++ b/src/Slot.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include "inc/Segment.h"
 #include "inc/Slot.h"
 #include "inc/Silf.h"

--- a/src/Sparse.cpp
+++ b/src/Sparse.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2011, SIL International, All rights reserved.
 
 #include <cassert>

--- a/src/Sparse.cpp
+++ b/src/Sparse.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2011, SIL International, All rights reserved.
 
-    Copyright 2011, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include <cassert>
 #include "inc/Sparse.h"
 #include "inc/bits.h"

--- a/src/TtfUtil.cpp
+++ b/src/TtfUtil.cpp
@@ -1,39 +1,14 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
-/*--------------------------------------------------------------------*//*:Ignore this sentence.
-
-File: TtfUtil.cpp
+/*
 Responsibility: Alan Ward
 Last reviewed: Not yet.
 
 Description
     Implements the methods for TtfUtil class. This file should remain portable to any C++
     environment by only using standard C++ and the TTF structurs defined in Tt.h.
--------------------------------------------------------------------------------*//*:End Ignore*/
+*/
 
 
 /***********************************************************************************************

--- a/src/TtfUtil.cpp
+++ b/src/TtfUtil.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 /*

--- a/src/UtfCodec.cpp
+++ b/src/UtfCodec.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include "inc/UtfCodec.h"
 //using namespace graphite2;
 

--- a/src/UtfCodec.cpp
+++ b/src/UtfCodec.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include "inc/UtfCodec.h"

--- a/src/call_machine.cpp
+++ b/src/call_machine.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 // This call threaded interpreter implmentation for machine.h

--- a/src/call_machine.cpp
+++ b/src/call_machine.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 // This call threaded interpreter implmentation for machine.h
 // Author: Tim Eves
 

--- a/src/direct_machine.cpp
+++ b/src/direct_machine.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 // This direct threaded interpreter implmentation for machine.h
 // Author: Tim Eves
 

--- a/src/direct_machine.cpp
+++ b/src/direct_machine.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 // This direct threaded interpreter implmentation for machine.h

--- a/src/files.mk
+++ b/src/files.mk
@@ -1,28 +1,5 @@
-#    GRAPHITE2 LICENSING
-#
-#    Copyright 2011, SIL International
-#    All rights reserved.
-#
-#    This library is free software; you can redistribute it and/or modify
-#    it under the terms of the GNU Lesser General Public License as published
-#    by the Free Software Foundation; either version 2.1 of License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-#    Lesser General Public License for more details.
-#
-#    You should also have received a copy of the GNU Lesser General Public
-#    License along with this library in the file named "LICENSE".
-#    If not, write to the Free Software Foundation, 51 Franklin Street,
-#    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-#    internet at http://www.fsf.org/licenses/lgpl.html.
-#
-# Alternatively, the contents of this file may be used under the terms of the
-# Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-# License, as published by the Free Software Foundation, either version 2
-# of the License or (at your option) any later version.
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2011, SIL International, All rights reserved.
 
 # Makefile helper file for those wanting to build Graphite2 using make
 # The including makefile should set the following variables

--- a/src/files.mk
+++ b/src/files.mk
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2011, SIL International, All rights reserved.
 
 # Makefile helper file for those wanting to build Graphite2 using make

--- a/src/gr_char_info.cpp
+++ b/src/gr_char_info.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include <cassert>

--- a/src/gr_char_info.cpp
+++ b/src/gr_char_info.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include <cassert>
 #include "graphite2/Segment.h"
 #include "inc/CharInfo.h"

--- a/src/gr_face.cpp
+++ b/src/gr_face.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include "graphite2/Font.h"

--- a/src/gr_face.cpp
+++ b/src/gr_face.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include "graphite2/Font.h"
 #include "inc/Face.h"
 #include "inc/FileFace.h"

--- a/src/gr_features.cpp
+++ b/src/gr_features.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include "graphite2/Font.h"

--- a/src/gr_features.cpp
+++ b/src/gr_features.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include "graphite2/Font.h"
 #include "inc/Face.h"
 #include "inc/FeatureMap.h"

--- a/src/gr_font.cpp
+++ b/src/gr_font.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include "graphite2/Font.h"

--- a/src/gr_font.cpp
+++ b/src/gr_font.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include "graphite2/Font.h"
 #include "inc/Font.h"
 

--- a/src/gr_logging.cpp
+++ b/src/gr_logging.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include <cstdio>

--- a/src/gr_logging.cpp
+++ b/src/gr_logging.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include <cstdio>
 
 #include "graphite2/Log.h"

--- a/src/gr_segment.cpp
+++ b/src/gr_segment.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include "graphite2/Segment.h"
 #include "inc/UtfCodec.h"
 #include "inc/Segment.h"

--- a/src/gr_segment.cpp
+++ b/src/gr_segment.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include "graphite2/Segment.h"

--- a/src/gr_slot.cpp
+++ b/src/gr_slot.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #include "graphite2/Segment.h"
 #include "inc/Segment.h"
 #include "inc/Slot.h"

--- a/src/gr_slot.cpp
+++ b/src/gr_slot.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #include "graphite2/Segment.h"

--- a/src/inc/CharInfo.h
+++ b/src/inc/CharInfo.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 #include "inc/Main.h"
 

--- a/src/inc/CharInfo.h
+++ b/src/inc/CharInfo.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/CmapCache.h
+++ b/src/inc/CmapCache.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 #include "inc/Main.h"

--- a/src/inc/CmapCache.h
+++ b/src/inc/CmapCache.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/Code.h
+++ b/src/inc/Code.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 // This class represents loaded graphite stack machine code.  It performs
 // basic sanity checks, on the incoming code to prevent more obvious problems
 // from crashing graphite.

--- a/src/inc/Code.h
+++ b/src/inc/Code.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 // This class represents loaded graphite stack machine code.  It performs

--- a/src/inc/Collider.h
+++ b/src/inc/Collider.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 #include "inc/List.h"

--- a/src/inc/Collider.h
+++ b/src/inc/Collider.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/Compression.h
+++ b/src/inc/Compression.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2015, SIL International, All rights reserved.
 
-    Copyright 2015, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 
 #pragma once
 

--- a/src/inc/Compression.h
+++ b/src/inc/Compression.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2015, SIL International, All rights reserved.
 
 

--- a/src/inc/Decompressor.h
+++ b/src/inc/Decompressor.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2015, SIL International, All rights reserved.
 
-    Copyright 2015, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 
 #pragma once
 

--- a/src/inc/Decompressor.h
+++ b/src/inc/Decompressor.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2015, SIL International, All rights reserved.
 
 

--- a/src/inc/Endian.h
+++ b/src/inc/Endian.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2011, SIL International, All rights reserved.
 /*
 Description:

--- a/src/inc/Endian.h
+++ b/src/inc/Endian.h
@@ -1,30 +1,5 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2011, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
-
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2011, SIL International, All rights reserved.
 /*
 Description:
     A set of fast template based decoders for decoding values of any C integer

--- a/src/inc/Error.h
+++ b/src/inc/Error.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2013, SIL International, All rights reserved.
 
-    Copyright 2013, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 // numbers are explicitly assigned for future proofing

--- a/src/inc/Error.h
+++ b/src/inc/Error.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2013, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/Face.h
+++ b/src/inc/Face.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/Face.h
+++ b/src/inc/Face.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 #include <cstdio>

--- a/src/inc/FeatureMap.h
+++ b/src/inc/FeatureMap.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 #include "inc/Main.h"
 #include "inc/FeatureVal.h"

--- a/src/inc/FeatureMap.h
+++ b/src/inc/FeatureMap.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/FeatureVal.h
+++ b/src/inc/FeatureVal.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 #include <cstring>
 #include <cassert>

--- a/src/inc/FeatureVal.h
+++ b/src/inc/FeatureVal.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/FileFace.h
+++ b/src/inc/FileFace.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2012, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/FileFace.h
+++ b/src/inc/FileFace.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2012, SIL International, All rights reserved.
 
-    Copyright 2012, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 //#include "inc/FeatureMap.h"

--- a/src/inc/Font.h
+++ b/src/inc/Font.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 #include <cassert>
 #include "graphite2/Font.h"

--- a/src/inc/Font.h
+++ b/src/inc/Font.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/GlyphCache.h
+++ b/src/inc/GlyphCache.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2012, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/GlyphCache.h
+++ b/src/inc/GlyphCache.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2012, SIL International, All rights reserved.
 
-    Copyright 2012, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 

--- a/src/inc/GlyphFace.h
+++ b/src/inc/GlyphFace.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 #include "inc/Main.h"

--- a/src/inc/GlyphFace.h
+++ b/src/inc/GlyphFace.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/Intervals.h
+++ b/src/inc/Intervals.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 #include <utility>

--- a/src/inc/Intervals.h
+++ b/src/inc/Intervals.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/List.h
+++ b/src/inc/List.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 
 // designed to have a limited subset of the std::vector api
 #pragma once

--- a/src/inc/List.h
+++ b/src/inc/List.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 

--- a/src/inc/Machine.h
+++ b/src/inc/Machine.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 // This general interpreter interface.
 // Author: Tim Eves
 

--- a/src/inc/Machine.h
+++ b/src/inc/Machine.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 // This general interpreter interface.

--- a/src/inc/Main.h
+++ b/src/inc/Main.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 #include <cstdlib>

--- a/src/inc/Main.h
+++ b/src/inc/Main.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/NameTable.h
+++ b/src/inc/NameTable.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 #include <graphite2/Segment.h>

--- a/src/inc/NameTable.h
+++ b/src/inc/NameTable.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/Pass.h
+++ b/src/inc/Pass.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 #include <cstdlib>

--- a/src/inc/Pass.h
+++ b/src/inc/Pass.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/Position.h
+++ b/src/inc/Position.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 namespace graphite2 {

--- a/src/inc/Position.h
+++ b/src/inc/Position.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/Rule.h
+++ b/src/inc/Rule.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2011, SIL International, All rights reserved.
 
-    Copyright 2011, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 
 #pragma once
 

--- a/src/inc/Rule.h
+++ b/src/inc/Rule.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2011, SIL International, All rights reserved.
 
 

--- a/src/inc/Segment.h
+++ b/src/inc/Segment.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 #include "inc/Main.h"

--- a/src/inc/Segment.h
+++ b/src/inc/Segment.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/Silf.h
+++ b/src/inc/Silf.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 #include "graphite2/Font.h"

--- a/src/inc/Silf.h
+++ b/src/inc/Silf.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/Slot.h
+++ b/src/inc/Slot.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 #include "graphite2/Types.h"

--- a/src/inc/Slot.h
+++ b/src/inc/Slot.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/Sparse.h
+++ b/src/inc/Sparse.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2011, SIL International, All rights reserved.
 
-    Copyright 2011, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 #include <iterator>
 #include <utility>

--- a/src/inc/Sparse.h
+++ b/src/inc/Sparse.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2011, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/TtfTypes.h
+++ b/src/inc/TtfTypes.h
@@ -1,39 +1,14 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
-/*--------------------------------------------------------------------*//*:Ignore this sentence.
-
-File: TtfTypes.h
+/*
 Responsibility: Tim Eves
 Last reviewed: Not yet.
 
 Description:
 Provides types required to represent the TTF basic types.
--------------------------------------------------------------------------------*//*:End Ignore*/
+*/
 
 
 //**********************************************************************************************

--- a/src/inc/TtfTypes.h
+++ b/src/inc/TtfTypes.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/TtfUtil.h
+++ b/src/inc/TtfUtil.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 /*
 Responsibility: Alan Ward

--- a/src/inc/TtfUtil.h
+++ b/src/inc/TtfUtil.h
@@ -1,39 +1,13 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
-#pragma once
-/*--------------------------------------------------------------------*//*:Ignore this sentence.
-
-File: TtfUtil.h
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
+/*
 Responsibility: Alan Ward
 Last reviewed: Not yet.
 
 Description:
     Utility class for handling TrueType font files.
-----------------------------------------------------------------------------------------------*/
+*/
+#pragma once
 
 
 #include <cstddef>

--- a/src/inc/UtfCodec.h
+++ b/src/inc/UtfCodec.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2011, SIL International, All rights reserved.
 
-    Copyright 2011, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 #include <cstdlib>

--- a/src/inc/UtfCodec.h
+++ b/src/inc/UtfCodec.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2011, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/bits.h
+++ b/src/inc/bits.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2012, SIL International, All rights reserved.
 
-    Copyright 2012, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 
 namespace graphite2

--- a/src/inc/bits.h
+++ b/src/inc/bits.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2012, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/debug.h
+++ b/src/inc/debug.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2011, SIL International, All rights reserved.
 
 //  debug.h

--- a/src/inc/debug.h
+++ b/src/inc/debug.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2011, SIL International, All rights reserved.
 
-    Copyright 2011, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 //  debug.h
 //
 //  Created on: 22 Dec 2011

--- a/src/inc/json.h
+++ b/src/inc/json.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2011, SIL International, All rights reserved.
 
-    Copyright 2011, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 // JSON pretty printer for graphite font debug output logging.
 // Created on: 15 Dec 2011
 //     Author: Tim Eves

--- a/src/inc/json.h
+++ b/src/inc/json.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2011, SIL International, All rights reserved.
 
 // JSON pretty printer for graphite font debug output logging.

--- a/src/inc/locale2lcid.h
+++ b/src/inc/locale2lcid.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 #include <cstring>
 #include <cassert>

--- a/src/inc/locale2lcid.h
+++ b/src/inc/locale2lcid.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/inc/opcode_table.h
+++ b/src/inc/opcode_table.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 // This file will be pulled into and integrated into a machine implmentation
 // DO NOT build directly
 #pragma once

--- a/src/inc/opcode_table.h
+++ b/src/inc/opcode_table.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 // This file will be pulled into and integrated into a machine implmentation

--- a/src/inc/opcodes.h
+++ b/src/inc/opcodes.h
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 #pragma once
 // This file will be pulled into and integrated into a machine implmentation
 // DO NOT build directly and under no circumstances ever #include headers in

--- a/src/inc/opcodes.h
+++ b/src/inc/opcodes.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 
 #pragma once

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2011, SIL International, All rights reserved.
 
-    Copyright 2011, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 // JSON debug logging
 // Author: Tim Eves
 

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2011, SIL International, All rights reserved.
 
 // JSON debug logging

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2010, SIL International, All rights reserved.
 project(testing)
 include(Graphite)
 include(CMakeDependentOption)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2010, SIL International, All rights reserved.
 project(testing)
 include(Graphite)

--- a/tests/bittwiddling/CMakeLists.txt
+++ b/tests/bittwiddling/CMakeLists.txt
@@ -1,4 +1,6 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.0 FATAL_ERROR)
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2014, SIL International, All rights reserved.
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
 project(bits)
 include(Graphite)
 include_directories(${graphite2_core_SOURCE_DIR})

--- a/tests/bittwiddling/CMakeLists.txt
+++ b/tests/bittwiddling/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2014, SIL International, All rights reserved.
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
 project(bits)

--- a/tests/bittwiddling/bits.cpp
+++ b/tests/bittwiddling/bits.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2014 SIL International
 /*
 Responsibility: Tim Eves

--- a/tests/bittwiddling/bits.cpp
+++ b/tests/bittwiddling/bits.cpp
@@ -1,32 +1,11 @@
-/*-----------------------------------------------------------------------------
-Copyright (C) 2011 SIL International
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2014 SIL International
+/*
 Responsibility: Tim Eves
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-
 Description:
 The test harness for the Sparse class. This validates the
 sparse classe is working correctly.
------------------------------------------------------------------------------*/
+*/
 
 #include <cassert>
 #include <iomanip>

--- a/tests/comparerenderer/CMakeLists.txt
+++ b/tests/comparerenderer/CMakeLists.txt
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2010, SIL International, All rights reserved.
 project(comparerenderer)
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")

--- a/tests/comparerenderer/CMakeLists.txt
+++ b/tests/comparerenderer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2010, SIL International, All rights reserved.
 project(comparerenderer)
 

--- a/tests/comparerenderer/CompareRenderer.cpp
+++ b/tests/comparerenderer/CompareRenderer.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR GPL-2.0-or-later-2.1-or-later
 // Copyright 2010, SIL International, All rights reserved.
 #include <cassert>
 #include <cstddef>

--- a/tests/comparerenderer/CompareRenderer.cpp
+++ b/tests/comparerenderer/CompareRenderer.cpp
@@ -1,24 +1,5 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-*/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright 2010, SIL International, All rights reserved.
 #include <cassert>
 #include <cstddef>
 #include <cstdlib>

--- a/tests/comparerenderer/FeatureParser.h
+++ b/tests/comparerenderer/FeatureParser.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR GPL-2.0-or-later-2.1-or-later
 // Copyright 2010, SIL International, All rights reserved.
 #pragma once
 

--- a/tests/comparerenderer/FeatureParser.h
+++ b/tests/comparerenderer/FeatureParser.h
@@ -1,24 +1,5 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-*/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright 2010, SIL International, All rights reserved.
 #pragma once
 
 #include <cstring>

--- a/tests/comparerenderer/Gr2Renderer.h
+++ b/tests/comparerenderer/Gr2Renderer.h
@@ -1,24 +1,5 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-*/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright 2010, SIL International, All rights reserved.
 #pragma once
 
 #include <new>

--- a/tests/comparerenderer/Gr2Renderer.h
+++ b/tests/comparerenderer/Gr2Renderer.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR GPL-2.0-or-later-2.1-or-later
 // Copyright 2010, SIL International, All rights reserved.
 #pragma once
 

--- a/tests/comparerenderer/RenderedLine.h
+++ b/tests/comparerenderer/RenderedLine.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR GPL-2.0-or-later-2.1-or-later
 // Copyright 2010, SIL International, All rights reserved.
 #pragma once
 

--- a/tests/comparerenderer/RenderedLine.h
+++ b/tests/comparerenderer/RenderedLine.h
@@ -1,24 +1,5 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-*/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright 2010, SIL International, All rights reserved.
 #pragma once
 
 #include <cassert>

--- a/tests/comparerenderer/Renderer.h
+++ b/tests/comparerenderer/Renderer.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR GPL-2.0-or-later-2.1-or-later
 // Copyright 2010, SIL International, All rights reserved.
 #pragma once
 

--- a/tests/comparerenderer/Renderer.h
+++ b/tests/comparerenderer/Renderer.h
@@ -1,24 +1,5 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-*/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright 2010, SIL International, All rights reserved.
 #pragma once
 
 #include "RenderedLine.h"

--- a/tests/comparerenderer/RendererOptions.h
+++ b/tests/comparerenderer/RendererOptions.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR GPL-2.0-or-later-2.1-or-later
 // Copyright 2010, SIL International, All rights reserved.
 #pragma once
 

--- a/tests/comparerenderer/RendererOptions.h
+++ b/tests/comparerenderer/RendererOptions.h
@@ -1,24 +1,5 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-*/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright 2010, SIL International, All rights reserved.
 #pragma once
 
 class Option

--- a/tests/corrupt.py
+++ b/tests/corrupt.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2011, SIL International, All rights reserved.
 
 import argparse

--- a/tests/corrupt.py
+++ b/tests/corrupt.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2011, SIL International, All rights reserved.
+
 import argparse
 import functools
 import os

--- a/tests/defuzz
+++ b/tests/defuzz
@@ -17,7 +17,7 @@ __version__ = "1.0"
 __date__ = "15 September 2012"
 __author__ = "Tim Eves <tim_eves@sil.org>"
 __license__ = '''
-SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 Copyright 2012, SIL International, All rights reserved.
 '''
 

--- a/tests/defuzz
+++ b/tests/defuzz
@@ -17,31 +17,8 @@ __version__ = "1.0"
 __date__ = "15 September 2012"
 __author__ = "Tim Eves <tim_eves@sil.org>"
 __license__ = '''
-GRAPHITE2 LICENSING
-
-    Copyright 2012, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributI might beed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
+SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+Copyright 2012, SIL International, All rights reserved.
 '''
 
 recm = re.compile(r'^(-?\d+)?\s*,\s*(0[xX][\da-fA-F]+)\s*,\s*'

--- a/tests/endian/CMakeLists.txt
+++ b/tests/endian/CMakeLists.txt
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2011, SIL International, All rights reserved.
 project(endian)
 
 include_directories(${graphite2_core_SOURCE_DIR})

--- a/tests/endian/CMakeLists.txt
+++ b/tests/endian/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2011, SIL International, All rights reserved.
 project(endian)
 

--- a/tests/endian/endiantest.cpp
+++ b/tests/endian/endiantest.cpp
@@ -1,28 +1,7 @@
-/*-----------------------------------------------------------------------------
-Copyright (C) 2011 SIL International
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2011 SIL International
+/*
 Responsibility: Tim Eves
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-
 Description:
 The test harness for the Endian.h template library.  This validates the
 Endian.h classes are working correctly and with all fundamental C/C++ integer
@@ -30,7 +9,7 @@ types. This may also be used for benchmarking by suppling the base two
 magnitude for the number of rounds to run.
 Adding -DHAVE_64_LONG to your compilers command line will test 64bit wide
 integers in addition to 32, 16 and 8 bit.
------------------------------------------------------------------------------*/
+*/
 #include <cstdlib>
 #include <string>
 #include "inc/Endian.h"

--- a/tests/endian/endiantest.cpp
+++ b/tests/endian/endiantest.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2011 SIL International
 /*
 Responsibility: Tim Eves

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2011, SIL International, All rights reserved.
 project(testexamples)
 

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -1,4 +1,5 @@
-
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2011, SIL International, All rights reserved.
 project(testexamples)
 
 include_directories(../../src)

--- a/tests/examples/cluster.c
+++ b/tests/examples/cluster.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later */
 /* Copyright 2011, SIL International, All rights reserved. */
 #include <graphite2/Segment.h>
 #include <stdio.h>

--- a/tests/examples/cluster.c
+++ b/tests/examples/cluster.c
@@ -1,4 +1,5 @@
-
+/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* Copyright 2011, SIL International, All rights reserved. */
 #include <graphite2/Segment.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/examples/features.c
+++ b/tests/examples/features.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later */
 /* Copyright 2011, SIL International, All rights reserved. */
 #include <graphite2/Font.h>
 #include <stdio.h>

--- a/tests/examples/features.c
+++ b/tests/examples/features.c
@@ -1,4 +1,5 @@
-
+/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* Copyright 2011, SIL International, All rights reserved. */
 #include <graphite2/Font.h>
 #include <stdio.h>
 

--- a/tests/examples/freetype.c
+++ b/tests/examples/freetype.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later */
 /* Copyright 2011, SIL International, All rights reserved. */
 #include <graphite2/Segment.h>
 #include <stdio.h>

--- a/tests/examples/freetype.c
+++ b/tests/examples/freetype.c
@@ -1,4 +1,5 @@
-
+/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* Copyright 2011, SIL International, All rights reserved. */
 #include <graphite2/Segment.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/examples/linebreak.c
+++ b/tests/examples/linebreak.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later */
 /* Copyright 2011, SIL International, All rights reserved. */
 #include <graphite2/Segment.h>
 #include <stdio.h>

--- a/tests/examples/linebreak.c
+++ b/tests/examples/linebreak.c
@@ -1,4 +1,5 @@
-
+/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* Copyright 2011, SIL International, All rights reserved. */
 #include <graphite2/Segment.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/examples/simple.c
+++ b/tests/examples/simple.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later */
 /* Copyright 2011, SIL International, All rights reserved. */
 #include <graphite2/Segment.h>
 #include <stdio.h>

--- a/tests/examples/simple.c
+++ b/tests/examples/simple.c
@@ -1,4 +1,5 @@
-
+/* SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later */
+/* Copyright 2011, SIL International, All rights reserved. */
 #include <graphite2/Segment.h>
 #include <stdio.h>
 

--- a/tests/featuremap/CMakeLists.txt
+++ b/tests/featuremap/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2010, SIL International, All rights reserved.
 project(featuremaptest)
 include(Graphite)

--- a/tests/featuremap/CMakeLists.txt
+++ b/tests/featuremap/CMakeLists.txt
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2010, SIL International, All rights reserved.
 project(featuremaptest)
 include(Graphite)
 include_directories(${graphite2_core_SOURCE_DIR})

--- a/tests/featuremap/featuremaptest.cpp
+++ b/tests/featuremap/featuremaptest.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR GPL-2.0-or-later-2.1-or-later
 // Copyright 2010, SIL International, All rights reserved.
 #include <cassert>
 #include <cstdlib>

--- a/tests/featuremap/featuremaptest.cpp
+++ b/tests/featuremap/featuremaptest.cpp
@@ -1,24 +1,5 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-*/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright 2010, SIL International, All rights reserved.
 #include <cassert>
 #include <cstdlib>
 #include <fstream>

--- a/tests/fnttxtrender
+++ b/tests/fnttxtrender
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2013, SIL International, All rights reserved.
 
 import argparse
 import codecs

--- a/tests/fnttxtrender
+++ b/tests/fnttxtrender
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2013, SIL International, All rights reserved.
 
 import argparse

--- a/tests/fuzz-tests/CMakeLists.txt
+++ b/tests/fuzz-tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2012, SIL International, All rights reserved.
 project(fuzztesting)
 

--- a/tests/fuzz-tests/CMakeLists.txt
+++ b/tests/fuzz-tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2012, SIL International, All rights reserved.
 project(fuzztesting)
 
 function(trimtail VAR RESULT)

--- a/tests/fuzz-tests/gr-fuzzer-font.cpp
+++ b/tests/fuzz-tests/gr-fuzzer-font.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2018, SIL International, All rights reserved.
 #include <graphite2/Font.h>
 

--- a/tests/fuzz-tests/gr-fuzzer-font.cpp
+++ b/tests/fuzz-tests/gr-fuzzer-font.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2018, SIL International, All rights reserved.
 #include <graphite2/Font.h>
 
 #include "graphite-fuzzer.hpp"

--- a/tests/fuzz-tests/gr-fuzzer-segment.cpp
+++ b/tests/fuzz-tests/gr-fuzzer-segment.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2018, SIL International, All rights reserved.
 #include <graphite2/Segment.h>
 

--- a/tests/fuzz-tests/gr-fuzzer-segment.cpp
+++ b/tests/fuzz-tests/gr-fuzzer-segment.cpp
@@ -1,29 +1,5 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2018, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2018, SIL International, All rights reserved.
 #include <graphite2/Segment.h>
 
 #include "graphite-fuzzer.hpp"

--- a/tests/fuzz-tests/graphite-fuzzer.hpp
+++ b/tests/fuzz-tests/graphite-fuzzer.hpp
@@ -1,29 +1,5 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2018, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2018, SIL International, All rights reserved.
 #include <cstddef>
 #include <cstdint>
 #include <cstring>

--- a/tests/fuzz-tests/graphite-fuzzer.hpp
+++ b/tests/fuzz-tests/graphite-fuzzer.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2018, SIL International, All rights reserved.
 #include <cstddef>
 #include <cstdint>

--- a/tests/fuzz-tests/hairball.py
+++ b/tests/fuzz-tests/hairball.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2012, SIL International, All rights reserved.
 import argparse
 import pathlib
 import struct

--- a/tests/fuzz-tests/hairball.py
+++ b/tests/fuzz-tests/hairball.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2012, SIL International, All rights reserved.
 import argparse
 import pathlib

--- a/tests/fuzzcomparerender
+++ b/tests/fuzzcomparerender
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2012, SIL International, All rights reserved.
 
 TESTSDIR=$(dirname $0)

--- a/tests/fuzzcomparerender
+++ b/tests/fuzzcomparerender
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2012, SIL International, All rights reserved.
 
 TESTSDIR=$(dirname $0)
 FONT=$1

--- a/tests/fuzztest
+++ b/tests/fuzztest
@@ -11,7 +11,7 @@ __version__ = "1.0"
 __date__    = "4 April 2012"
 __author__  = "Tim Eves <tim_eves@sil.org>"
 __license__ ='''
-SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 Copyright 2010, SIL International, All rights reserved.
 '''
 import collections, operator, struct

--- a/tests/fuzztest
+++ b/tests/fuzztest
@@ -11,31 +11,8 @@ __version__ = "1.0"
 __date__    = "4 April 2012"
 __author__  = "Tim Eves <tim_eves@sil.org>"
 __license__ ='''
-GRAPHITE2 LICENSING
-
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributI might beed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
+SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+Copyright 2010, SIL International, All rights reserved.
 '''
 import collections, operator, struct
 from contextlib import closing, contextmanager

--- a/tests/grlist/CMakeLists.txt
+++ b/tests/grlist/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2010, SIL International, All rights reserved.
 project(grlisttest)
 

--- a/tests/grlist/CMakeLists.txt
+++ b/tests/grlist/CMakeLists.txt
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2010, SIL International, All rights reserved.
 project(grlisttest)
 
 include_directories(${graphite2_core_SOURCE_DIR})

--- a/tests/grlist/grlisttest.cpp
+++ b/tests/grlist/grlisttest.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2010, SIL International, All rights reserved.
 #include <cstdlib>
 #include <cstdio>

--- a/tests/grlist/grlisttest.cpp
+++ b/tests/grlist/grlisttest.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2010, SIL International, All rights reserved.
 #include <cstdlib>
 #include <cstdio>
 #include <cassert>

--- a/tests/grlist/intervalsettest.cpp
+++ b/tests/grlist/intervalsettest.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2014, SIL International, All rights reserved.
 #include "inc/Intervals.h"
 #include <utility>

--- a/tests/grlist/intervalsettest.cpp
+++ b/tests/grlist/intervalsettest.cpp
@@ -1,29 +1,5 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2014, SIL International, All rights reserved.
 #include "inc/Intervals.h"
 #include <utility>
 #include <vector>

--- a/tests/hbspeeds
+++ b/tests/hbspeeds
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2015, SIL International, All rights reserved.
 '''
 Tool to read callgrind output and return the net cost of the first call
 to a given function

--- a/tests/hbspeeds
+++ b/tests/hbspeeds
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2015, SIL International, All rights reserved.
 '''
 Tool to read callgrind output and return the net cost of the first call

--- a/tests/json/CMakeLists.txt
+++ b/tests/json/CMakeLists.txt
@@ -1,4 +1,6 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.0 FATAL_ERROR)
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2011, SIL International, All rights reserved.
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
 project(jsontest)
 include(Graphite)
 include_directories(${graphite2_core_SOURCE_DIR})

--- a/tests/json/CMakeLists.txt
+++ b/tests/json/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2011, SIL International, All rights reserved.
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
 project(jsontest)

--- a/tests/json/jsontest.cpp
+++ b/tests/json/jsontest.cpp
@@ -1,29 +1,6 @@
-/*  GRAPHITE2 LICENSING
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2011, SIL International, All rights reserved.
 
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-*/
 // JSON debug logging very basic test harness
 // Author: Tim Eves
 #include "inc/json.h"

--- a/tests/json/jsontest.cpp
+++ b/tests/json/jsontest.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2011, SIL International, All rights reserved.
 
 // JSON debug logging very basic test harness

--- a/tests/jsoncmp
+++ b/tests/jsoncmp
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2012, SIL International, All rights reserved.
 import json
 import operator

--- a/tests/jsoncmp
+++ b/tests/jsoncmp
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2012, SIL International, All rights reserved.
 import json
 import operator
 import re
@@ -20,7 +22,8 @@ def walktree(tree, path="", parent=None):
 
 def settreeval(parent, path, value):
     p = path.split("/")[-1]
-    if p.isdigit():  p = int(p)
+    if p.isdigit():
+        p = int(p)
     parent[p] = value
 
 

--- a/tests/nametabletest/CMakeLists.txt
+++ b/tests/nametabletest/CMakeLists.txt
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2010, SIL International, All rights reserved.
 project(nametabletest)
 include_directories(${graphite2_core_SOURCE_DIR})
 

--- a/tests/nametabletest/CMakeLists.txt
+++ b/tests/nametabletest/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2010, SIL International, All rights reserved.
 project(nametabletest)
 include_directories(${graphite2_core_SOURCE_DIR})

--- a/tests/nametabletest/nametabletest.cpp
+++ b/tests/nametabletest/nametabletest.cpp
@@ -1,24 +1,5 @@
-/*  GRAPHITE2 LICENSING
-
-    Copyright 2010, SIL International
-    All rights reserved.
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-*/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright 2010, SIL International, All rights reserved.
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>

--- a/tests/nametabletest/nametabletest.cpp
+++ b/tests/nametabletest/nametabletest.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR GPL-2.0-or-later-2.1-or-later
 // Copyright 2010, SIL International, All rights reserved.
 #include <cassert>
 #include <cstdio>

--- a/tests/run-fuzz-tests.sh
+++ b/tests/run-fuzz-tests.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2012, SIL International, All rights reserved.
 
 TESTSDIR=$(dirname $0)

--- a/tests/run-fuzz-tests.sh
+++ b/tests/run-fuzz-tests.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2012, SIL International, All rights reserved.
 
 TESTSDIR=$(dirname $0)
 for FONT in $(ls $TESTSDIR/fuzz-tests)

--- a/tests/sparsetest/CMakeLists.txt
+++ b/tests/sparsetest/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2012, SIL International, All rights reserved.
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
 project(sparsetest)

--- a/tests/sparsetest/CMakeLists.txt
+++ b/tests/sparsetest/CMakeLists.txt
@@ -1,4 +1,6 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.0 FATAL_ERROR)
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2012, SIL International, All rights reserved.
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
 project(sparsetest)
 include(Graphite)
 include_directories(${graphite2_core_SOURCE_DIR})

--- a/tests/sparsetest/sparsetest.cpp
+++ b/tests/sparsetest/sparsetest.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2012 SIL International
 /*
 Responsibility: Tim Eves

--- a/tests/sparsetest/sparsetest.cpp
+++ b/tests/sparsetest/sparsetest.cpp
@@ -1,32 +1,11 @@
-/*-----------------------------------------------------------------------------
-Copyright (C) 2011 SIL International
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2012 SIL International
+/*
 Responsibility: Tim Eves
-
-    This library is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should also have received a copy of the GNU Lesser General Public
-    License along with this library in the file named "LICENSE".
-    If not, write to the Free Software Foundation, 51 Franklin Street,
-    Suite 500, Boston, MA 02110-1335, USA or visit their web page on the
-    internet at http://www.fsf.org/licenses/lgpl.html.
-
-Alternatively, the contents of this file may be used under the terms of the
-Mozilla Public License (http://mozilla.org/MPL) or the GNU General Public
-License, as published by the Free Software Foundation, either version 2
-of the License or (at your option) any later version.
-
 Description:
 The test harness for the Sparse class. This validates the
 sparse classe is working correctly.
------------------------------------------------------------------------------*/
+*/
 
 #include <iostream>
 #include <string>

--- a/tests/trace2svg
+++ b/tests/trace2svg
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2016, SIL International, All rights reserved.
 
 

--- a/tests/trace2svg
+++ b/tests/trace2svg
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2016, SIL International, All rights reserved.
+
 
 from fontTools import ttLib
 from fontTools.pens.basePen import BasePen

--- a/tests/utftest/CMakeLists.txt
+++ b/tests/utftest/CMakeLists.txt
@@ -1,4 +1,6 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.0 FATAL_ERROR)
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2011, SIL International, All rights reserved.
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
 project(utftest)
 include(Graphite)
 include_directories(${graphite2_core_SOURCE_DIR})

--- a/tests/utftest/CMakeLists.txt
+++ b/tests/utftest/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2011, SIL International, All rights reserved.
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
 project(utftest)

--- a/tests/utftest/utftest.cpp
+++ b/tests/utftest/utftest.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright 2011, SIL International, All rights reserved.
 #include <graphite2/Segment.h>
 #include <stdio.h>

--- a/tests/utftest/utftest.cpp
+++ b/tests/utftest/utftest.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright 2011, SIL International, All rights reserved.
 #include <graphite2/Segment.h>
 #include <stdio.h>
 

--- a/tests/vm/CMakeLists.txt
+++ b/tests/vm/CMakeLists.txt
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# Copyright 2010, SIL International, All rights reserved.
 project(vm-testing)
 include(Graphite)
 

--- a/tests/vm/CMakeLists.txt
+++ b/tests/vm/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+# SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 # Copyright 2010, SIL International, All rights reserved.
 project(vm-testing)
 include(Graphite)

--- a/tests/vm/basic_test.cpp
+++ b/tests/vm/basic_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// SPDX-License-Identifier: MIT OR MPL-2.0 OR LGPL-2.1-or-later OR GPL-2.0-or-later
 // Copyright (C) 2010 SIL International
 #include <cstdlib>
 #include <iostream>

--- a/tests/vm/basic_test.cpp
+++ b/tests/vm/basic_test.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MPL-2.0 OR GPL-2.0-or-later
+// Copyright (C) 2010 SIL International
 #include <cstdlib>
 #include <iostream>
 #include <vector>
@@ -169,17 +171,3 @@ std::vector<byte> random_sequence(size_t n)
 
     return seq;
 }
-
-/*
-std::vector<byte> fuzzer(int n)
-{
-    std::vector<byte>   code(256);
-    std::vector<bool>   covered(256);
-
-    // Track stack depth to ensure we don't create programs that
-    //  overflow or underflow the stack.
-    size_t stack_depth = 0;
-
-    return code;
-}
-*/


### PR DESCRIPTION
Replace verbose notices and the top of each file with SPDX-LIcense-Identifiers, and add MIT as a license option.