### PR TITLE
Correction to Graphite versions used in apps

### DIFF
--- a/site/graphite_devApp.md
+++ b/site/graphite_devApp.md
@@ -34,10 +34,10 @@ The GitHub repository includes a [&#x2197; manual for integrating Graphite2 into
 >
 > SilGraphite is deprecated. Further development on the engine is not expected, and it is possible that it may not support fonts developed in the future.
 
-The original Graphite engine, packaged under the name SilGraphite, is used by OpenOffice, Fieldworks, and WorldPad.
+The original Graphite engine, packaged under the name SilGraphite, was once used by OpenOffice, Fieldworks, and WorldPad, which have long since been upgraded to use Graphite2.
 
 The source code can be downloaded from: [&#x2197; SilGraphite SourceForge project](http://sourceforge.net/projects/silgraphite/){:target="_blank"}.
 
 [&#x2197; SilGraphite Application Programmers Guide](assets/resources/SilGraphite_AppProgGuide.pdf)
 
-(The documents above describe version 2 of the Graphite API; the original API is obsolete.)
+(The documents above describe version 2 of the SilGraphite API; the original API is obsolete.)


### PR DESCRIPTION
The apps listed as using SilGraphite have not used that version for since perhaps 10-15 years ago. As far as I know (the exception being WorldPad) none of the currently use Silgraohite. I've tried to clarify that in this PR.

Also tried to make the description about which version of the API is described by the SilGraphite PDF a little clearer, as my first reading suggested the doc described the Graphite2 API, rather than version 2 of the SilGraphite API.