### PR TITLE
tests/featuremap/featuremaptest.cpp: add missing <stdint.h> include

### DIFF
--- a/tests/featuremap/featuremaptest.cpp
+++ b/tests/featuremap/featuremaptest.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <stdint.h>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Without the change `graphite` build fails on upcoming `gcc-15` as:

    tests/featuremap/featuremaptest.cpp:30:15: error: 'uint8_t' was not declared in this scope
       30 |   std::vector<uint8_t> _ttf;
          |               ^~~~~~~
    tests/featuremap/featuremaptest.cpp:16:1: note: 'uint8_t' is defined in header '<cstdint>';
      this is probably fixable by adding '#include <cstdint>'
       15 | #include "inc/Face.h"
      +++ |+#include <cstdint>
       16 | #include "inc/FeatureMap.h"