### PR TITLE
tests: fix nametabletest NameRecord conversion bounds

### DIFF
--- a/tests/nametabletest/nametabletest.cpp
+++ b/tests/nametabletest/nametabletest.cpp
@@ -118,7 +118,7 @@ template <class T> T * toBigEndian(T & table)
     bigEndian->m_nameHeader.count = be::swap<uint16>(table.m_nameHeader.count);
     bigEndian->m_nameHeader.string_offset = be::swap<uint16>(table.m_nameHeader.string_offset);
 
-    for (uint16 i = 0; i < table.m_nameHeader.count; i++)
+    for (uint16 i = 0; i + 1 < table.m_nameHeader.count; i++)
     {
         bigEndian->m_records[i].platform_id = be::swap<uint16>(table.m_records[i].platform_id);
         bigEndian->m_records[i].platform_specific_id = be::swap<uint16>(table.m_records[i].platform_specific_id);


### PR DESCRIPTION
The synthetic name-table builder copied one too many NameRecord entries in toBigEndian().

FontNames already contains name_record[0], while m_records stores only the remaining count-1 records. The loop used count, so for NameTestB (count=8, m_records[7]) it wrote past m_records and corrupted adjacent fields (m_langTagCount/lang tags).

That memory corruption breaks format 1 language-tag lookup and causes fallback behavior.

Fixes: #96